### PR TITLE
Territory languages

### DIFF
--- a/databases/iso_territory_languages.json
+++ b/databases/iso_territory_languages.json
@@ -2,6787 +2,8162 @@
   "territory_languages": [
     {
       "alpha_2": "BD", 
-      "languages": {
-        "bn": {
+      "languages": [
+        {
+          "lang": "bn", 
           "official": true, 
           "percent": 98.0
         }, 
-        "ccp": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "en": {
+        {
+          "lang": "en", 
           "official": false, 
           "percent": 18.0
         }, 
-        "grt": {
+        {
+          "lang": "rkt", 
+          "official": false, 
+          "percent": 6.5
+        }, 
+        {
+          "lang": "syl", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "ccp", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "my", 
+          "official": false, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "grt", 
           "official": false, 
           "percent": 0.073
         }, 
-        "mni": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "mro": {
+        {
+          "lang": "mro", 
           "official": false, 
           "percent": 0.018
         }, 
-        "my": {
+        {
+          "lang": "mni", 
           "official": false, 
-          "percent": 0.21
-        }, 
-        "rkt": {
-          "official": false, 
-          "percent": 6.5
-        }, 
-        "syl": {
-          "official": false, 
-          "percent": 5.0
+          "percent": 0.011
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BE", 
-      "languages": {
-        "de": {
-          "official": true, 
-          "percent": 22.0
-        }, 
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": false, 
           "percent": 59.0
         }, 
-        "fr": {
-          "official": true, 
-          "percent": 38.0
-        }, 
-        "nl": {
+        {
+          "lang": "nl", 
           "official": true, 
           "percent": 55.0
         }, 
-        "vls": {
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 38.0
+        }, 
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 22.0
+        }, 
+        {
+          "lang": "vls", 
           "official": false, 
           "percent": 10.0
         }, 
-        "wa": {
+        {
+          "lang": "wa", 
           "official": false, 
           "percent": 5.8
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BF", 
-      "languages": {
-        "dyu": {
+      "languages": [
+        {
+          "lang": "mos", 
+          "official": false, 
+          "percent": 40.0
+        }, 
+        {
+          "lang": "dyu", 
           "official": false, 
           "percent": 32.0
         }, 
-        "fr": {
+        {
+          "lang": "fr", 
           "official": true, 
           "percent": 22.0
-        }, 
-        "mos": {
-          "official": false, 
-          "percent": 40.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BG", 
-      "languages": {
-        "bg": {
+      "languages": [
+        {
+          "lang": "bg", 
           "official": true, 
           "percent": 100.0
         }, 
-        "de": {
-          "official": false, 
-          "percent": 8.0
-        }, 
-        "en": {
+        {
+          "lang": "en", 
           "official": false, 
           "percent": 25.0
         }, 
-        "ru": {
+        {
+          "lang": "ru", 
           "official": false, 
           "percent": 23.0
         }, 
-        "tr": {
+        {
+          "lang": "tr", 
           "official": false, 
           "percent": 11.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 8.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BA", 
-      "languages": {
-        "bs": {
+      "languages": [
+        {
+          "lang": "bs", 
           "official": true, 
           "percent": 99.0
         }, 
-        "bs_Cyrl": {
+        {
+          "lang": "bs_Cyrl", 
           "official": true, 
           "percent": 99.0
         }, 
-        "en": {
+        {
+          "lang": "en", 
           "official": false, 
           "percent": 45.0
         }, 
-        "hr": {
+        {
+          "lang": "hr", 
           "official": true, 
           "percent": 12.0
         }, 
-        "sr": {
+        {
+          "lang": "sr", 
           "official": true, 
           "percent": 10.0
         }, 
-        "sr_Latn": {
+        {
+          "lang": "sr_Latn", 
           "official": true, 
           "percent": 10.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BB", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 100.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "WF", 
-      "languages": {
-        "fr": {
+      "languages": [
+        {
+          "lang": "wls", 
+          "official": false, 
+          "percent": 60.0
+        }, 
+        {
+          "lang": "fr", 
           "official": true, 
           "percent": 48.0
         }, 
-        "fud": {
+        {
+          "lang": "fud", 
           "official": false, 
           "percent": 31.0
-        }, 
-        "wls": {
-          "official": false, 
-          "percent": 60.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BL", 
-      "languages": {
-        "fr": {
+      "languages": [
+        {
+          "lang": "fr", 
           "official": true, 
           "percent": 95.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BM", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 92.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BN", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 1.8
-        }, 
-        "ms": {
+      "languages": [
+        {
+          "lang": "ms", 
           "official": true, 
           "percent": 93.0
         }, 
-        "ms_Arab": {
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "ms_Arab", 
           "official": true, 
           "percent": 5.0
         }, 
-        "zh_Hant": {
+        {
+          "lang": "en", 
           "official": false, 
-          "percent": 11.0
+          "percent": 1.8
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BO", 
-      "languages": {
-        "aro": {
-          "official": false, 
-          "percent": 0.001
-        }, 
-        "ay": {
-          "official": true, 
-          "percent": 20.0
-        }, 
-        "es": {
+      "languages": [
+        {
+          "lang": "es", 
           "official": true, 
           "percent": 61.0
         }, 
-        "gn": {
+        {
+          "lang": "qu", 
+          "official": true, 
+          "percent": 32.0
+        }, 
+        {
+          "lang": "ay", 
+          "official": true, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "gn", 
           "official": false, 
           "percent": 0.45
         }, 
-        "qu": {
-          "official": true, 
-          "percent": 32.0
+        {
+          "lang": "aro", 
+          "official": false, 
+          "percent": 0.001
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BH", 
-      "languages": {
-        "ar": {
+      "languages": [
+        {
+          "lang": "ar", 
           "official": true, 
           "percent": 87.0
         }, 
-        "ml": {
+        {
+          "lang": "ml", 
           "official": false, 
           "percent": 3.3
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BI", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 0.054
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 59.0
-        }, 
-        "rn": {
+      "languages": [
+        {
+          "lang": "rn", 
           "official": true, 
           "percent": 63.0
         }, 
-        "sw": {
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 59.0
+        }, 
+        {
+          "lang": "sw", 
           "official": false, 
           "percent": 0.055
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 0.054
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BJ", 
-      "languages": {
-        "fon": {
-          "official": false, 
-          "percent": 25.0
-        }, 
-        "fr": {
+      "languages": [
+        {
+          "lang": "fr", 
           "official": true, 
           "percent": 35.0
         }, 
-        "yo": {
+        {
+          "lang": "fon", 
+          "official": false, 
+          "percent": 25.0
+        }, 
+        {
+          "lang": "yo", 
           "official": false, 
           "percent": 6.7
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BT", 
-      "languages": {
-        "dz": {
+      "languages": [
+        {
+          "lang": "dz", 
           "official": true, 
           "percent": 47.0
         }, 
-        "en": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "lep": {
-          "official": false, 
-          "percent": 3.9
-        }, 
-        "ne": {
+        {
+          "lang": "ne", 
           "official": false, 
           "percent": 17.0
         }, 
-        "tsj": {
+        {
+          "lang": "tsj", 
           "official": false, 
           "percent": 15.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "lep", 
+          "official": false, 
+          "percent": 3.9
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "JM", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 98.0
         }, 
-        "jam": {
+        {
+          "lang": "jam", 
           "official": false, 
           "percent": 95.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BV", 
-      "languages": {
-        "und": {
+      "languages": [
+        {
+          "lang": "und", 
           "official": false, 
           "percent": 100.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BW", 
-      "languages": {
-        "af": {
-          "official": false, 
-          "percent": 0.27
-        }, 
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 81.0
         }, 
-        "tn": {
+        {
+          "lang": "tn", 
           "official": true, 
           "percent": 62.0
+        }, 
+        {
+          "lang": "af", 
+          "official": false, 
+          "percent": 0.27
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "WS", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 2.2
-        }, 
-        "sm": {
+      "languages": [
+        {
+          "lang": "sm", 
           "official": true, 
           "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 2.2
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BQ", 
-      "languages": {
-        "nl": {
-          "official": true, 
-          "percent": 8.0
-        }, 
-        "pap": {
+      "languages": [
+        {
+          "lang": "pap", 
           "official": false, 
           "percent": 81.0
+        }, 
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 8.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BR", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 0.84
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 8.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 0.037
-        }, 
-        "gub": {
-          "official": false, 
-          "percent": 0.0084
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 0.28
-        }, 
-        "ja": {
-          "official": false, 
-          "percent": 0.21
-        }, 
-        "kgp": {
-          "official": false, 
-          "percent": 0.01
-        }, 
-        "ko": {
-          "official": false, 
-          "percent": 0.021
-        }, 
-        "pt": {
+      "languages": [
+        {
+          "lang": "pt", 
           "official": true, 
           "percent": 91.0
         }, 
-        "xav": {
+        {
+          "lang": "en", 
           "official": false, 
-          "percent": 0.0048
+          "percent": 8.0
         }, 
-        "yrl": {
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 0.84
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 0.28
+        }, 
+        {
+          "lang": "ja", 
+          "official": false, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 0.037
+        }, 
+        {
+          "lang": "ko", 
+          "official": false, 
+          "percent": 0.021
+        }, 
+        {
+          "lang": "kgp", 
+          "official": false, 
+          "percent": 0.01
+        }, 
+        {
+          "lang": "gub", 
+          "official": false, 
+          "percent": 0.0084
+        }, 
+        {
+          "lang": "yrl", 
           "official": false, 
           "percent": 0.0052
+        }, 
+        {
+          "lang": "xav", 
+          "official": false, 
+          "percent": 0.0048
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BS", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 100.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "JE", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 95.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BY", 
-      "languages": {
-        "be": {
+      "languages": [
+        {
+          "lang": "be", 
           "official": true, 
           "percent": 100.0
         }, 
-        "ru": {
+        {
+          "lang": "ru", 
           "official": true, 
           "percent": 12.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "BZ", 
-      "languages": {
-        "en": {
+      "languages": [
+        {
+          "lang": "en", 
           "official": true, 
           "percent": 100.0
         }, 
-        "es": {
+        {
+          "lang": "es", 
           "official": false, 
           "percent": 28.0
         }
-      }
+      ]
     }, 
     {
       "alpha_2": "RU", 
-      "languages": {
-        "ady": {
+      "languages": [
+        {
+          "lang": "ru", 
+          "official": true, 
+          "percent": 94.0
+        }, 
+        {
+          "lang": "tt", 
+          "official": true, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "ba", 
+          "official": true, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "cv", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 0.84
+        }, 
+        {
+          "lang": "ce", 
+          "official": true, 
+          "percent": 0.66
+        }, 
+        {
+          "lang": "av", 
+          "official": true, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "udm", 
+          "official": true, 
+          "percent": 0.38
+        }, 
+        {
+          "lang": "chm", 
+          "official": false, 
+          "percent": 0.37
+        }, 
+        {
+          "lang": "os", 
+          "official": false, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "sah", 
+          "official": true, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "kbd", 
+          "official": true, 
+          "percent": 0.31
+        }, 
+        {
+          "lang": "myv", 
+          "official": true, 
+          "percent": 0.31
+        }, 
+        {
+          "lang": "dar", 
+          "official": false, 
+          "percent": 0.26
+        }, 
+        {
+          "lang": "bua", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "mdf", 
+          "official": true, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "kum", 
+          "official": true, 
+          "percent": 0.2
+        }, 
+        {
+          "lang": "kv", 
+          "official": true, 
+          "percent": 0.18
+        }, 
+        {
+          "lang": "lez", 
+          "official": true, 
+          "percent": 0.18
+        }, 
+        {
+          "lang": "inh", 
+          "official": true, 
+          "percent": 0.16
+        }, 
+        {
+          "lang": "krc", 
+          "official": true, 
+          "percent": 0.16
+        }, 
+        {
+          "lang": "tyv", 
+          "official": true, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "az_Cyrl", 
+          "official": true, 
+          "percent": 0.093
+        }, 
+        {
+          "lang": "ady", 
           "official": true, 
           "percent": 0.088
         }, 
-        "alt": {
-          "official": false, 
-          "percent": 0.014
-        }, 
-        "av": {
-          "official": true, 
-          "percent": 0.39
-        }, 
-        "az_Cyrl": {
-          "official": true, 
-          "percent": 0.093
-        }, 
-        "ba": {
-          "official": true, 
-          "percent": 1.3
-        }, 
-        "bua": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "ce": {
-          "official": true, 
-          "percent": 0.66
-        }, 
-        "chm": {
-          "official": false, 
-          "percent": 0.37
-        }, 
-        "cu": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "cv": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "dar": {
-          "official": false, 
-          "percent": 0.26
-        }, 
-        "fi": {
-          "official": false, 
-          "percent": 0.012
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 0.84
-        }, 
-        "inh": {
-          "official": true, 
-          "percent": 0.16
-        }, 
-        "izh": {
-          "official": false, 
-          "percent": 0.0001
-        }, 
-        "kbd": {
-          "official": true, 
-          "percent": 0.31
-        }, 
-        "koi": {
-          "official": true, 
-          "percent": 0.045
-        }, 
-        "krc": {
-          "official": true, 
-          "percent": 0.16
-        }, 
-        "krl": {
+        {
+          "lang": "krl", 
           "official": false, 
           "percent": 0.082
         }, 
-        "kum": {
-          "official": true, 
-          "percent": 0.2
-        }, 
-        "kv": {
-          "official": true, 
-          "percent": 0.18
-        }, 
-        "lbe": {
+        {
+          "lang": "lbe", 
           "official": true, 
           "percent": 0.078
         }, 
-        "lez": {
+        {
+          "lang": "koi", 
           "official": true, 
-          "percent": 0.18
-        }, 
-        "mdf": {
-          "official": true, 
-          "percent": 0.21
-        }, 
-        "mn": {
-          "official": false, 
-          "percent": 0.0015
-        }, 
-        "mrj": {
-          "official": false, 
-          "percent": 0.021
-        }, 
-        "myv": {
-          "official": true, 
-          "percent": 0.31
-        }, 
-        "os": {
-          "official": false, 
-          "percent": 0.32
-        }, 
-        "ru": {
-          "official": true, 
-          "percent": 94.0
-        }, 
-        "sah": {
-          "official": true, 
-          "percent": 0.32
-        }, 
-        "sr_Latn": {
-          "official": false, 
-          "percent": 0.0035
-        }, 
-        "tt": {
-          "official": true, 
-          "percent": 1.4
-        }, 
-        "tyv": {
-          "official": true, 
-          "percent": 0.13
-        }, 
-        "udm": {
-          "official": true, 
-          "percent": 0.38
-        }, 
-        "vep": {
-          "official": false, 
-          "percent": 0.0025
-        }, 
-        "vot": {
-          "official": false, 
-          "percent": 0.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "RW", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 15.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 0.019
-        }, 
-        "rw": {
-          "official": true, 
-          "percent": 77.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "RS", 
-      "languages": {
-        "hr": {
-          "official": true, 
-          "percent": 0.93
-        }, 
-        "hu": {
-          "official": true, 
-          "percent": 4.8
-        }, 
-        "ro": {
-          "official": true, 
-          "percent": 2.1
-        }, 
-        "sk": {
-          "official": true, 
-          "percent": 0.85
-        }, 
-        "sq": {
-          "official": false, 
-          "percent": 19.0
-        }, 
-        "sr": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "sr_Latn": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "uk": {
-          "official": true, 
-          "percent": 0.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TL", 
-      "languages": {
-        "pt": {
-          "official": true, 
-          "percent": 59.0
-        }, 
-        "tet": {
-          "official": true, 
-          "percent": 59.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "RE", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 89.0
-        }, 
-        "rcf": {
-          "official": false, 
-          "percent": 71.0
-        }, 
-        "ta": {
-          "official": false, 
-          "percent": 15.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TM", 
-      "languages": {
-        "ku": {
-          "official": false, 
-          "percent": 0.41
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 12.0
-        }, 
-        "tk": {
-          "official": true, 
-          "percent": 70.0
-        }, 
-        "uz": {
-          "official": false, 
-          "percent": 9.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TJ", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 0.012
-        }, 
-        "fa": {
-          "official": false, 
-          "percent": 0.78
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 12.0
-        }, 
-        "tg": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "RO", 
-      "languages": {
-        "bg": {
-          "official": false, 
-          "percent": 0.031
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 0.21
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.019
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 31.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 10.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "hu": {
-          "official": false, 
-          "percent": 6.6
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 0.013
-        }, 
-        "ro": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "sr_Latn": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 0.13
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TK", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "tkl": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GW", 
-      "languages": {
-        "knf": {
-          "official": false, 
-          "percent": 2.6
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GU", 
-      "languages": {
-        "ch": {
-          "official": true, 
-          "percent": 22.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 91.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GT", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "quc": {
-          "official": true, 
-          "percent": 7.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GS", 
-      "languages": {
-        "und": {
-          "official": false, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GR", 
-      "languages": {
-        "bg": {
-          "official": false, 
-          "percent": 0.27
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "el": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 51.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 9.0
-        }, 
-        "mk": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "pnt": {
-          "official": false, 
-          "percent": 3.7
-        }, 
-        "sq": {
-          "official": false, 
-          "percent": 0.093
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "tsd": {
-          "official": false, 
-          "percent": 0.0019
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GQ", 
-      "languages": {
-        "bvb": {
-          "official": false, 
-          "percent": 7.9
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 87.0
-        }, 
-        "fan": {
-          "official": false, 
-          "percent": 51.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 8.8
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 0.0001
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GP", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 90.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "JP", 
-      "languages": {
-        "ja": {
-          "official": true, 
-          "percent": 95.0
-        }, 
-        "ko": {
-          "official": false, 
-          "percent": 0.52
-        }, 
-        "ryu": {
-          "official": false, 
-          "percent": 0.77
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GY", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GF", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 77.0
-        }, 
-        "gcr": {
-          "official": false, 
-          "percent": 26.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 2.5
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GE", 
-      "languages": {
-        "ab": {
-          "official": true, 
-          "percent": 2.2
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "ka": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "ku": {
-          "official": false, 
-          "percent": 0.89
-        }, 
-        "os": {
-          "official": true, 
-          "percent": 2.2
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 9.0
-        }, 
-        "xmf": {
-          "official": false, 
-          "percent": 11.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GD", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 96.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GB", 
-      "languages": {
-        "bn": {
-          "official": false, 
-          "percent": 0.67
-        }, 
-        "cy": {
-          "official": true, 
-          "percent": 0.77
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 19.0
-        }, 
-        "ga": {
-          "official": true, 
-          "percent": 0.026
-        }, 
-        "gd": {
-          "official": true, 
-          "percent": 0.099
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "ks": {
-          "official": false, 
-          "percent": 0.19
-        }, 
-        "kw": {
-          "official": false, 
-          "percent": 0.0031
-        }, 
-        "ml": {
-          "official": false, 
-          "percent": 0.035
-        }, 
-        "pa": {
-          "official": false, 
-          "percent": 0.79
-        }, 
-        "sco": {
-          "official": false, 
-          "percent": 2.7
-        }, 
-        "syl": {
-          "official": false, 
-          "percent": 0.51
-        }, 
-        "yi": {
-          "official": false, 
-          "percent": 0.049
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 0.54
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GA", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 63.0
-        }, 
-        "puu": {
-          "official": false, 
-          "percent": 9.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SV", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 89.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GN", 
-      "languages": {
-        "ff": {
-          "official": false, 
-          "percent": 26.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 29.0
-        }, 
-        "kpe": {
-          "official": false, 
-          "percent": 3.8
-        }, 
-        "man_Nkoo": {
-          "official": false, 
-          "percent": 23.0
-        }, 
-        "nqo": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "sus": {
-          "official": false, 
-          "percent": 11.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GM", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 40.0
-        }, 
-        "man": {
-          "official": false, 
-          "percent": 29.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GL", 
-      "languages": {
-        "da": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "kl": {
-          "official": true, 
-          "percent": 84.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GI", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 80.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 50.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "GH", 
-      "languages": {
-        "abr": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "ada": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "ak": {
-          "official": true, 
-          "percent": 39.0
-        }, 
-        "ee": {
-          "official": true, 
-          "percent": 11.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 21.0
-        }, 
-        "gaa": {
-          "official": true, 
-          "percent": 2.8
-        }, 
-        "gur": {
-          "official": false, 
-          "percent": 3.5
-        }, 
-        "ha": {
-          "official": false, 
-          "percent": 0.87
-        }, 
-        "nzi": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "saf": {
-          "official": false, 
-          "percent": 0.015
-        }
-      }
-    }, 
-    {
-      "alpha_2": "OM", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 81.0
-        }, 
-        "bal": {
-          "official": false, 
-          "percent": 4.9
-        }, 
-        "fa": {
-          "official": false, 
-          "percent": 0.94
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TN", 
-      "languages": {
-        "aeb": {
-          "official": false, 
-          "percent": 90.0
-        }, 
-        "ar": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 74.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "JO", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 45.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TA", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HR", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 49.0
-        }, 
-        "hr": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "it": {
-          "official": true, 
-          "percent": 1.6
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HT", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 4.7
-        }, 
-        "ht": {
-          "official": true, 
-          "percent": 81.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HU", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 18.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 20.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "hr": {
-          "official": false, 
-          "percent": 0.32
-        }, 
-        "hu": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "ro": {
-          "official": false, 
-          "percent": 0.99
-        }, 
-        "sk": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "sl": {
-          "official": false, 
-          "percent": 0.051
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HK", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 51.0
-        }, 
-        "yue": {
-          "official": false, 
-          "percent": 90.0
-        }, 
-        "zh": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "zh_Hant": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HN", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 0.44
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 78.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "HM", 
-      "languages": {
-        "und": {
-          "official": false, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VE", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 82.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PR", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 49.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 87.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PS", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PW", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 8.8
-        }, 
-        "pau": {
-          "official": true, 
-          "percent": 74.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PT", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 10.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 15.0
-        }, 
-        "gl": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 96.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SJ", 
-      "languages": {
-        "nb": {
-          "official": true, 
-          "percent": 56.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 45.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PY", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 2.9
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 3.2
-        }, 
-        "gn": {
-          "official": true, 
-          "percent": 80.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IQ", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 68.0
-        }, 
-        "az_Arab": {
-          "official": true, 
-          "percent": 1.8
-        }, 
-        "ckb": {
-          "official": true, 
-          "percent": 20.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 35.0
-        }, 
-        "fa": {
-          "official": false, 
-          "percent": 0.87
-        }, 
-        "lrc": {
-          "official": false, 
-          "percent": 0.61
-        }, 
-        "syr": {
-          "official": false, 
-          "percent": 0.5
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PA", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 69.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 0.16
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PF", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 61.0
-        }, 
-        "ty": {
-          "official": true, 
-          "percent": 31.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 7.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 50.0
-        }, 
-        "ho": {
-          "official": true, 
-          "percent": 2.1
-        }, 
-        "tpi": {
-          "official": true, 
-          "percent": 71.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PE", 
-      "languages": {
-        "ay": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 73.0
-        }, 
-        "qu": {
-          "official": true, 
-          "percent": 15.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PK", 
-      "languages": {
-        "bal": {
-          "official": false, 
-          "percent": 3.7
-        }, 
-        "bft": {
-          "official": false, 
-          "percent": 0.18
-        }, 
-        "bgn": {
-          "official": false, 
-          "percent": 0.57
-        }, 
-        "brh": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "btv": {
-          "official": false, 
-          "percent": 0.019
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 50.0
-        }, 
-        "fa": {
-          "official": false, 
-          "percent": 0.66
-        }, 
-        "gjk": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "gju": {
-          "official": false, 
-          "percent": 0.2
-        }, 
-        "hnd": {
-          "official": false, 
-          "percent": 0.41
-        }, 
-        "hno": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "khw": {
-          "official": false, 
-          "percent": 0.15
-        }, 
-        "ks": {
-          "official": false, 
-          "percent": 0.069
-        }, 
-        "kvx": {
-          "official": false, 
-          "percent": 0.16
-        }, 
-        "kxp": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "lah": {
-          "official": false, 
-          "percent": 40.0
-        }, 
-        "mvy": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "pa_Arab": {
-          "official": false, 
-          "percent": 70.0
-        }, 
-        "ps": {
-          "official": false, 
-          "percent": 15.0
-        }, 
-        "sd": {
-          "official": false, 
-          "percent": 12.0
-        }, 
-        "skr": {
-          "official": false, 
-          "percent": 9.1
-        }, 
-        "tg_Arab": {
-          "official": false, 
-          "percent": 0.33
-        }, 
-        "ur": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PH", 
-      "languages": {
-        "bhk": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "bik": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "bku": {
-          "official": false, 
-          "percent": 0.0077
-        }, 
-        "bto": {
-          "official": false, 
-          "percent": 0.28
-        }, 
-        "ceb": {
-          "official": true, 
-          "percent": 24.0
-        }, 
-        "cps": {
-          "official": false, 
-          "percent": 0.67
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 64.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 31.0
-        }, 
-        "fil": {
-          "official": true, 
-          "percent": 60.0
-        }, 
-        "hil": {
-          "official": true, 
-          "percent": 8.4
-        }, 
-        "hnn": {
-          "official": false, 
-          "percent": 0.016
-        }, 
-        "ilo": {
-          "official": true, 
-          "percent": 9.6
-        }, 
-        "krj": {
-          "official": false, 
-          "percent": 0.39
-        }, 
-        "mdh": {
-          "official": true, 
-          "percent": 1.2
-        }, 
-        "pag": {
-          "official": true, 
-          "percent": 1.4
-        }, 
-        "pam": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "tbw": {
-          "official": false, 
-          "percent": 0.0096
-        }, 
-        "tsg": {
-          "official": true, 
-          "percent": 1.1
-        }, 
-        "war": {
-          "official": true, 
-          "percent": 2.9
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 0.73
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PN", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 85.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PL", 
-      "languages": {
-        "be": {
-          "official": false, 
-          "percent": 0.58
-        }, 
-        "csb": {
-          "official": true, 
-          "percent": 0.13
-        }, 
-        "de": {
-          "official": true, 
-          "percent": 19.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 33.0
-        }, 
-        "lt": {
-          "official": true, 
-          "percent": 0.021
-        }, 
-        "pl": {
-          "official": true, 
-          "percent": 96.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 18.0
-        }, 
-        "sli": {
-          "official": false, 
-          "percent": 0.031
-        }, 
-        "szl": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "uk": {
-          "official": false, 
-          "percent": 0.39
-        }
-      }
-    }, 
-    {
-      "alpha_2": "PM", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 3.4
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 92.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ZM", 
-      "languages": {
-        "bem": {
-          "official": false, 
-          "percent": 31.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 16.0
-        }, 
-        "loz": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "ny": {
-          "official": false, 
-          "percent": 15.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "EH", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "EE", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 50.0
-        }, 
-        "et": {
-          "official": true, 
-          "percent": 71.0
-        }, 
-        "fi": {
-          "official": false, 
-          "percent": 21.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 56.0
-        }, 
-        "vro": {
-          "official": false, 
-          "percent": 5.7
-        }
-      }
-    }, 
-    {
-      "alpha_2": "EG", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 94.0
-        }, 
-        "arz": {
-          "official": false, 
-          "percent": 64.0
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.061
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 35.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "EA", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ZA", 
-      "languages": {
-        "af": {
-          "official": true, 
-          "percent": 13.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 31.0
-        }, 
-        "hi": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "nr": {
-          "official": true, 
-          "percent": 1.6
-        }, 
-        "nso": {
-          "official": true, 
-          "percent": 9.4
-        }, 
-        "ss": {
-          "official": true, 
-          "percent": 2.7
-        }, 
-        "st": {
-          "official": true, 
-          "percent": 7.9
-        }, 
-        "sw": {
-          "official": false, 
-          "percent": 0.0018
-        }, 
-        "tn": {
-          "official": true, 
-          "percent": 8.2
-        }, 
-        "ts": {
-          "official": true, 
-          "percent": 4.4
-        }, 
-        "ve": {
-          "official": true, 
-          "percent": 2.3
-        }, 
-        "xh": {
-          "official": true, 
-          "percent": 18.0
-        }, 
-        "zu": {
-          "official": true, 
-          "percent": 24.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "EC", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 96.0
-        }, 
-        "qu": {
-          "official": true, 
-          "percent": 17.0
-        }, 
-        "qug": {
-          "official": false, 
-          "percent": 5.7
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IT", 
-      "languages": {
-        "ca": {
-          "official": false, 
-          "percent": 0.035
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "egl": {
-          "official": false, 
-          "percent": 0.05
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.035
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 34.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 6.3
-        }, 
-        "fur": {
-          "official": false, 
-          "percent": 0.06
-        }, 
-        "hr": {
-          "official": false, 
-          "percent": 0.0056
-        }, 
-        "it": {
-          "official": true, 
-          "percent": 95.0
-        }, 
-        "lij": {
-          "official": false, 
-          "percent": 0.86
-        }, 
-        "lmo": {
-          "official": false, 
-          "percent": 0.03
-        }, 
-        "nap": {
-          "official": false, 
-          "percent": 0.97
-        }, 
-        "pms": {
-          "official": false, 
-          "percent": 0.0099
-        }, 
-        "rgn": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "sc": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "scn": {
-          "official": false, 
-          "percent": 0.82
-        }, 
-        "sdc": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "sl": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "vec": {
-          "official": false, 
-          "percent": 1.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VN", 
-      "languages": {
-        "cjm": {
-          "official": false, 
-          "percent": 0.089
-        }, 
-        "vi": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 1.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ZZ", 
-      "languages": {}
-    }, 
-    {
-      "alpha_2": "SB", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "rug": {
-          "official": false, 
-          "percent": 1.5
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ET", 
-      "languages": {
-        "aa": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "am": {
-          "official": true, 
-          "percent": 33.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 43.0
-        }, 
-        "om": {
-          "official": false, 
-          "percent": 32.0
-        }, 
-        "sid": {
-          "official": false, 
-          "percent": 3.5
-        }, 
-        "so": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "ti": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "wal": {
-          "official": false, 
-          "percent": 1.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SO", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 34.0
-        }, 
-        "om": {
-          "official": false, 
-          "percent": 0.42
-        }, 
-        "so": {
-          "official": true, 
-          "percent": 78.0
-        }, 
-        "sw": {
-          "official": false, 
-          "percent": 2.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ZW", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 42.0
-        }, 
-        "kck": {
-          "official": false, 
-          "percent": 5.3
-        }, 
-        "mxc": {
-          "official": false, 
-          "percent": 6.5
-        }, 
-        "nd": {
-          "official": true, 
-          "percent": 12.0
-        }, 
-        "ndc": {
-          "official": false, 
-          "percent": 6.1
-        }, 
-        "ny": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "sn": {
-          "official": true, 
-          "percent": 81.0
-        }, 
-        "tn": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "ve": {
-          "official": false, 
-          "percent": 0.64
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SA", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ES", 
-      "languages": {
-        "ast": {
-          "official": true, 
-          "percent": 1.3
-        }, 
-        "ca": {
-          "official": true, 
-          "percent": 17.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 24.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "eu": {
-          "official": true, 
-          "percent": 2.0
-        }, 
-        "ext": {
-          "official": false, 
-          "percent": 0.49
-        }, 
-        "gl": {
-          "official": true, 
-          "percent": 7.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ER", 
-      "languages": {
-        "aa": {
-          "official": false, 
-          "percent": 3.6
-        }, 
-        "ar": {
-          "official": true, 
-          "percent": 4.9
-        }, 
-        "byn": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 59.0
-        }, 
-        "ssy": {
-          "official": false, 
-          "percent": 3.6
-        }, 
-        "ti": {
-          "official": true, 
-          "percent": 60.0
-        }, 
-        "tig": {
-          "official": false, 
-          "percent": 18.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ME", 
-      "languages": {
-        "sq": {
-          "official": false, 
-          "percent": 7.9
-        }, 
-        "sr": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "sr_Latn": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MD", 
-      "languages": {
-        "bg": {
-          "official": false, 
-          "percent": 9.4
-        }, 
-        "gag": {
-          "official": false, 
-          "percent": 3.3
-        }, 
-        "ro": {
-          "official": true, 
-          "percent": 63.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "uk": {
-          "official": false, 
-          "percent": 14.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 18.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 69.0
-        }, 
-        "mg": {
-          "official": true, 
-          "percent": 90.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MF", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MA", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 62.0
-        }, 
-        "ary": {
-          "official": false, 
-          "percent": 87.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 0.065
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 20.0
-        }, 
-        "rif": {
-          "official": false, 
-          "percent": 4.9
-        }, 
-        "rif_Latn": {
-          "official": false, 
-          "percent": 4.9
-        }, 
-        "shi": {
-          "official": false, 
-          "percent": 8.7
-        }, 
-        "shi_Latn": {
-          "official": false, 
-          "percent": 8.7
-        }, 
-        "tzm": {
-          "official": true, 
-          "percent": 9.8
-        }, 
-        "zgh": {
-          "official": false, 
-          "percent": 22.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MC", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "UZ", 
-      "languages": {
-        "kaa": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 0.76
-        }, 
-        "uz": {
-          "official": true, 
-          "percent": 85.0
-        }, 
-        "uz_Cyrl": {
-          "official": true, 
-          "percent": 15.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MM", 
-      "languages": {
-        "kac": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "kht": {
-          "official": false, 
-          "percent": 0.0077
-        }, 
-        "mnw": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "my": {
-          "official": true, 
-          "percent": 64.0
-        }, 
-        "shn": {
-          "official": false, 
-          "percent": 6.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ML", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 0.89
-        }, 
-        "bm": {
-          "official": false, 
-          "percent": 46.0
-        }, 
-        "bm_Nkoo": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "bmq": {
-          "official": false, 
-          "percent": 0.86
-        }, 
-        "bze": {
-          "official": false, 
-          "percent": 0.84
-        }, 
-        "dtm": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "ffm": {
-          "official": false, 
-          "percent": 7.7
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 46.0
-        }, 
-        "kao": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "khq": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "mwk": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "ses": {
-          "official": false, 
-          "percent": 3.4
-        }, 
-        "snk": {
-          "official": false, 
-          "percent": 5.9
-        }, 
-        "tmh": {
-          "official": false, 
-          "percent": 2.1
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MO", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 5.0
-        }, 
-        "zh": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "zh_Hant": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MN", 
-      "languages": {
-        "kk_Arab": {
-          "official": false, 
-          "percent": 7.2
-        }, 
-        "mn": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 0.13
-        }, 
-        "ug_Cyrl": {
-          "official": false, 
-          "percent": 0.033
-        }, 
-        "zh": {
-          "official": false, 
-          "percent": 1.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MH", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "mh": {
-          "official": true, 
-          "percent": 73.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MK", 
-      "languages": {
-        "mk": {
-          "official": true, 
-          "percent": 67.0
-        }, 
-        "sq": {
-          "official": true, 
-          "percent": 25.0
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 3.5
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MU", 
-      "languages": {
-        "bho": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 72.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 3.0
-        }, 
-        "mfe": {
-          "official": false, 
-          "percent": 90.0
-        }, 
-        "ta": {
-          "official": false, 
-          "percent": 2.5
-        }, 
-        "ur": {
-          "official": false, 
-          "percent": 5.2
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MT", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 88.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 56.0
-        }, 
-        "mt": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MW", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 63.0
-        }, 
-        "ny": {
-          "official": true, 
-          "percent": 63.0
-        }, 
-        "tog": {
-          "official": false, 
-          "percent": 0.98
-        }, 
-        "tum": {
-          "official": false, 
-          "percent": 8.4
-        }, 
-        "zu": {
-          "official": false, 
-          "percent": 0.33
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MV", 
-      "languages": {
-        "dv": {
-          "official": true, 
-          "percent": 94.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MQ", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MP", 
-      "languages": {
-        "ch": {
-          "official": false, 
-          "percent": 18.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 97.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MS", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 66.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MR", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 85.0
-        }, 
-        "ff": {
-          "official": false, 
-          "percent": 5.7
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "wo": {
-          "official": false, 
-          "percent": 0.27
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IM", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "gv": {
-          "official": true, 
-          "percent": 1.9
-        }
-      }
-    }, 
-    {
-      "alpha_2": "UG", 
-      "languages": {
-        "ach": {
-          "official": false, 
-          "percent": 3.7
-        }, 
-        "cgg": {
-          "official": false, 
-          "percent": 5.4
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 3.9
-        }, 
-        "hi": {
-          "official": false, 
-          "percent": 0.0056
-        }, 
-        "laj": {
-          "official": false, 
-          "percent": 3.8
-        }, 
-        "lg": {
-          "official": false, 
-          "percent": 13.0
-        }, 
-        "myx": {
-          "official": false, 
-          "percent": 2.9
-        }, 
-        "nyn": {
-          "official": false, 
-          "percent": 6.3
-        }, 
-        "rw": {
-          "official": false, 
-          "percent": 2.1
-        }, 
-        "sw": {
-          "official": true, 
-          "percent": 75.0
-        }, 
-        "teo": {
-          "official": false, 
-          "percent": 3.9
-        }, 
-        "ttj": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "xog": {
-          "official": false, 
-          "percent": 5.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TZ", 
-      "languages": {
-        "asa": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "bez": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 69.0
-        }, 
-        "jmc": {
-          "official": false, 
-          "percent": 0.75
-        }, 
-        "kde": {
-          "official": false, 
-          "percent": 2.4
-        }, 
-        "ksb": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "lag": {
-          "official": false, 
-          "percent": 0.87
-        }, 
-        "mas": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "mgy": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "nym": {
-          "official": false, 
-          "percent": 3.3
-        }, 
-        "rof": {
-          "official": false, 
-          "percent": 0.75
-        }, 
-        "rwk": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "sbp": {
-          "official": false, 
-          "percent": 0.2
-        }, 
-        "suk": {
-          "official": false, 
-          "percent": 8.7
-        }, 
-        "sw": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "vun": {
-          "official": false, 
-          "percent": 0.75
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MY", 
-      "languages": {
-        "bjn": {
-          "official": false, 
-          "percent": 0.016
-        }, 
-        "bug": {
-          "official": false, 
-          "percent": 0.079
-        }, 
-        "dtp": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 21.0
-        }, 
-        "iba": {
-          "official": false, 
-          "percent": 2.5
-        }, 
-        "jv": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "ml": {
-          "official": false, 
-          "percent": 0.15
-        }, 
-        "ms": {
-          "official": true, 
-          "percent": 75.0
-        }, 
-        "ta": {
-          "official": false, 
-          "percent": 4.2
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "zmi": {
-          "official": false, 
-          "percent": 1.2
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MX", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 13.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 83.0
-        }, 
-        "maz": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "nch": {
-          "official": false, 
-          "percent": 0.19
-        }, 
-        "nhe": {
-          "official": false, 
-          "percent": 0.39
-        }, 
-        "nhw": {
-          "official": false, 
-          "percent": 0.38
-        }, 
-        "sei": {
-          "official": false, 
-          "percent": 0.0007
-        }, 
-        "yua": {
-          "official": false, 
-          "percent": 0.67
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IL", 
-      "languages": {
-        "am": {
-          "official": false, 
-          "percent": 0.59
-        }, 
-        "ar": {
-          "official": true, 
-          "percent": 20.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 85.0
-        }, 
-        "he": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "hu": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "lad": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "ml": {
-          "official": false, 
-          "percent": 0.096
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "ro": {
-          "official": false, 
-          "percent": 3.7
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "ti": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "yi": {
-          "official": false, 
-          "percent": 3.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FR", 
-      "languages": {
-        "br": {
-          "official": false, 
-          "percent": 0.83
-        }, 
-        "ca": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "co": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 39.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 13.0
-        }, 
-        "eu": {
-          "official": false, 
-          "percent": 0.13
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 99.0
-        }, 
-        "frp": {
-          "official": false, 
-          "percent": 0.094
-        }, 
-        "gsw": {
-          "official": false, 
-          "percent": 0.91
-        }, 
-        "ia": {
-          "official": false, 
-          "percent": 0.0002
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "nl": {
-          "official": false, 
-          "percent": 0.13
-        }, 
-        "oc": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "pcd": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "pt": {
-          "official": false, 
-          "percent": 1.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IO", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SH", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 69.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FI", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 18.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 70.0
-        }, 
-        "et": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "fi": {
-          "official": true, 
-          "percent": 94.0
-        }, 
-        "rmf": {
-          "official": false, 
-          "percent": 0.091
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 0.81
-        }, 
-        "se": {
-          "official": false, 
-          "percent": 0.036
-        }, 
-        "smn": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "sms": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "sv": {
-          "official": true, 
-          "percent": 44.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FJ", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 94.0
-        }, 
-        "fj": {
-          "official": true, 
-          "percent": 39.0
-        }, 
-        "hi": {
-          "official": false, 
-          "percent": 44.0
-        }, 
-        "hif": {
-          "official": true, 
-          "percent": 41.0
-        }, 
-        "rtm": {
-          "official": false, 
-          "percent": 0.27
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FK", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 96.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FM", 
-      "languages": {
-        "chk": {
-          "official": false, 
-          "percent": 30.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 57.0
-        }, 
-        "kos": {
-          "official": false, 
-          "percent": 7.7
-        }, 
-        "pon": {
-          "official": false, 
-          "percent": 23.0
-        }, 
-        "uli": {
-          "official": false, 
-          "percent": 2.9
-        }, 
-        "yap": {
-          "official": false, 
-          "percent": 6.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "FO", 
-      "languages": {
-        "fo": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NI", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 78.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NL", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 71.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 90.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 29.0
-        }, 
-        "fy": {
-          "official": true, 
-          "percent": 4.3
-        }, 
-        "gos": {
-          "official": false, 
-          "percent": 3.6
-        }, 
-        "id": {
-          "official": false, 
-          "percent": 1.8
-        }, 
-        "li": {
-          "official": false, 
-          "percent": 5.5
-        }, 
-        "nds": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "nl": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "rif_Latn": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "zea": {
-          "official": false, 
-          "percent": 1.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NO", 
-      "languages": {
-        "nb": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "nn": {
-          "official": true, 
-          "percent": 25.0
-        }, 
-        "se": {
-          "official": true, 
-          "percent": 0.29
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NA", 
-      "languages": {
-        "af": {
-          "official": false, 
-          "percent": 75.0
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 0.9
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 7.0
-        }, 
-        "hz": {
-          "official": false, 
-          "percent": 9.1
-        }, 
-        "kj": {
-          "official": false, 
-          "percent": 35.0
-        }, 
-        "naq": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "ng": {
-          "official": false, 
-          "percent": 21.0
-        }, 
-        "tn": {
-          "official": false, 
-          "percent": 0.56
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VU", 
-      "languages": {
-        "bi": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 83.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 50.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NC", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 96.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NE", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 0.21
-        }, 
-        "dje": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 29.0
-        }, 
-        "fuq": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "ha": {
-          "official": false, 
-          "percent": 41.0
-        }, 
-        "tmh": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "twq": {
-          "official": false, 
-          "percent": 0.042
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NF", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 76.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NG", 
-      "languages": {
-        "amo": {
-          "official": false, 
-          "percent": 0.0087
-        }, 
-        "ar": {
-          "official": false, 
-          "percent": 0.071
-        }, 
-        "bin": {
-          "official": false, 
-          "percent": 0.71
-        }, 
-        "cch": {
-          "official": false, 
-          "percent": 0.021
-        }, 
-        "efi": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 53.0
-        }, 
-        "fuv": {
-          "official": false, 
-          "percent": 6.7
-        }, 
-        "ha": {
-          "official": false, 
-          "percent": 13.0
-        }, 
-        "ha_Arab": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "ibb": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "ig": {
-          "official": false, 
-          "percent": 13.0
-        }, 
-        "kaj": {
-          "official": false, 
-          "percent": 0.21
-        }, 
-        "kcg": {
-          "official": false, 
-          "percent": 0.093
-        }, 
-        "pcm": {
-          "official": false, 
-          "percent": 21.0
-        }, 
-        "tiv": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "yo": {
-          "official": true, 
-          "percent": 13.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NZ", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 98.0
-        }, 
-        "mi": {
-          "official": true, 
-          "percent": 2.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NP", 
-      "languages": {
-        "awa": {
-          "official": false, 
-          "percent": 2.2
-        }, 
-        "bap": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "bfy": {
-          "official": false, 
-          "percent": 0.54
-        }, 
-        "bho": {
-          "official": false, 
-          "percent": 6.8
-        }, 
-        "bn": {
-          "official": false, 
-          "percent": 0.094
-        }, 
-        "bo": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "dty": {
-          "official": false, 
-          "percent": 2.5
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "ggn": {
-          "official": false, 
-          "percent": 0.42
-        }, 
-        "gvr": {
-          "official": false, 
-          "percent": 0.29
-        }, 
-        "hi": {
-          "official": false, 
-          "percent": 0.42
-        }, 
-        "jml": {
-          "official": false, 
-          "percent": 3.2
-        }, 
-        "lep": {
-          "official": false, 
-          "percent": 0.0096
-        }, 
-        "lif": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "mai": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "mgp": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "mrd": {
-          "official": false, 
-          "percent": 0.83
-        }, 
-        "ne": {
-          "official": true, 
-          "percent": 44.0
-        }, 
-        "new": {
-          "official": false, 
-          "percent": 3.3
-        }, 
-        "rjs": {
-          "official": false, 
-          "percent": 0.44
-        }, 
-        "taj": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "tdg": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "tdh": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "thl": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "thq": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "thr": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "tkt": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "tsf": {
-          "official": false, 
-          "percent": 0.43
-        }, 
-        "unr_Deva": {
-          "official": false, 
-          "percent": 0.019
-        }, 
-        "xsr": {
-          "official": false, 
-          "percent": 0.52
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NR", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 97.0
-        }, 
-        "na": {
-          "official": true, 
-          "percent": 71.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "NU", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 69.0
-        }, 
-        "niu": {
-          "official": true, 
-          "percent": 69.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CK", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "XK", 
-      "languages": {
-        "aln": {
-          "official": false, 
-          "percent": 74.0
-        }, 
-        "sq": {
-          "official": true, 
-          "percent": 92.0
-        }, 
-        "sr": {
-          "official": true, 
-          "percent": 5.0
-        }, 
-        "sr_Latn": {
-          "official": true, 
-          "percent": 5.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CI", 
-      "languages": {
-        "bci": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "bqv": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "dnj": {
-          "official": false, 
-          "percent": 4.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 49.0
-        }, 
-        "kfo": {
-          "official": false, 
-          "percent": 0.23
-        }, 
-        "sef": {
-          "official": false, 
-          "percent": 4.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CH", 
-      "languages": {
-        "de": {
-          "official": true, 
-          "percent": 73.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 61.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 21.0
-        }, 
-        "gsw": {
-          "official": true, 
-          "percent": 65.0
-        }, 
-        "it": {
-          "official": true, 
-          "percent": 4.3
-        }, 
-        "lmo": {
-          "official": false, 
-          "percent": 4.1
-        }, 
-        "pt": {
-          "official": false, 
-          "percent": 3.4
-        }, 
-        "rm": {
-          "official": true, 
-          "percent": 0.5
-        }, 
-        "rmo": {
-          "official": false, 
-          "percent": 0.29
-        }, 
-        "wae": {
-          "official": false, 
-          "percent": 0.12
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CO", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "guc": {
-          "official": false, 
-          "percent": 0.27
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CN", 
-      "languages": {
-        "bo": {
-          "official": true, 
-          "percent": 0.2
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 0.0045
-        }, 
-        "gan": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "hak": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "hsn": {
-          "official": false, 
-          "percent": 2.9
-        }, 
-        "ii": {
-          "official": false, 
-          "percent": 0.6
-        }, 
-        "khb": {
-          "official": false, 
-          "percent": 0.019
-        }, 
-        "kk_Arab": {
-          "official": false, 
-          "percent": 0.086
-        }, 
-        "ko": {
-          "official": true, 
-          "percent": 0.15
-        }, 
-        "ky_Arab": {
-          "official": false, 
-          "percent": 0.034
-        }, 
-        "lcp": {
-          "official": false, 
-          "percent": 0.0058
-        }, 
-        "lis": {
-          "official": false, 
           "percent": 0.045
         }, 
-        "lzh": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "mn_Mong": {
-          "official": true, 
-          "percent": 0.26
-        }, 
-        "nan": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "nxq": {
-          "official": false, 
-          "percent": 0.024
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 0.001
-        }, 
-        "tdd": {
-          "official": false, 
-          "percent": 0.019
-        }, 
-        "ug": {
-          "official": true, 
-          "percent": 0.55
-        }, 
-        "uz_Cyrl": {
-          "official": false, 
-          "percent": 0.0004
-        }, 
-        "vi": {
-          "official": false, 
-          "percent": 0.0005
-        }, 
-        "wuu": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "yue_Hans": {
-          "official": false, 
-          "percent": 5.2
-        }, 
-        "za": {
-          "official": true, 
-          "percent": 0.31
-        }, 
-        "zh": {
-          "official": true, 
-          "percent": 90.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CM", 
-      "languages": {
-        "agq": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "ar": {
-          "official": false, 
-          "percent": 0.39
-        }, 
-        "bas": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "bax": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "bbj": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "bfd": {
-          "official": false, 
-          "percent": 0.57
-        }, 
-        "bkm": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "bss": {
-          "official": false, 
-          "percent": 0.54
-        }, 
-        "bum": {
-          "official": false, 
-          "percent": 4.6
-        }, 
-        "byv": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "dua": {
-          "official": false, 
-          "percent": 0.48
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 38.0
-        }, 
-        "ewo": {
-          "official": false, 
-          "percent": 3.1
-        }, 
-        "ff": {
-          "official": false, 
-          "percent": 3.6
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 68.0
-        }, 
-        "ha_Arab": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "jgo": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "kkj": {
-          "official": false, 
-          "percent": 0.54
-        }, 
-        "ksf": {
-          "official": false, 
-          "percent": 0.32
-        }, 
-        "maf": {
-          "official": false, 
-          "percent": 0.73
-        }, 
-        "mgo": {
-          "official": false, 
-          "percent": 0.47
-        }, 
-        "mua": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "nmg": {
-          "official": false, 
-          "percent": 0.036
-        }, 
-        "nnh": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "yav": {
-          "official": false, 
-          "percent": 0.0092
-        }, 
-        "ybb": {
-          "official": false, 
-          "percent": 1.6
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CL", 
-      "languages": {
-        "arn": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 9.5
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CC", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 17.0
-        }, 
-        "ms_Arab": {
-          "official": false, 
-          "percent": 83.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CA", 
-      "languages": {
-        "atj": {
-          "official": false, 
-          "percent": 0.016
-        }, 
-        "chp": {
-          "official": false, 
-          "percent": 0.0022
-        }, 
-        "cr": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "crj": {
+        {
+          "lang": "mrj", 
           "official": false, 
           "percent": 0.021
         }, 
-        "crk": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "crl": {
-          "official": false, 
-          "percent": 0.015
-        }, 
-        "crm": {
-          "official": false, 
-          "percent": 0.013
-        }, 
-        "csw": {
+        {
+          "lang": "alt", 
           "official": false, 
           "percent": 0.014
         }, 
-        "de": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "den": {
-          "official": false, 
-          "percent": 0.0065
-        }, 
-        "dgr": {
-          "official": false, 
-          "percent": 0.0074
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 22.0
-        }, 
-        "gwi": {
-          "official": false, 
-          "percent": 0.0016
-        }, 
-        "ikt": {
-          "official": true, 
-          "percent": 0.011
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "iu": {
-          "official": true, 
-          "percent": 0.042
-        }, 
-        "iu_Latn": {
-          "official": true, 
-          "percent": 0.042
-        }, 
-        "moe": {
-          "official": false, 
-          "percent": 0.033
-        }, 
-        "moh": {
-          "official": false, 
-          "percent": 0.0098
-        }, 
-        "nsk": {
-          "official": false, 
-          "percent": 0.0033
-        }, 
-        "pdt": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "scs": {
-          "official": false, 
-          "percent": 0.0035
-        }, 
-        "yi": {
-          "official": false, 
-          "percent": 0.045
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CG", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 84.0
-        }, 
-        "ln": {
-          "official": false, 
-          "percent": 2.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CF", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 49.0
-        }, 
-        "ln": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "sg": {
-          "official": true, 
-          "percent": 49.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CD", 
-      "languages": {
-        "fr": {
-          "official": true, 
-          "percent": 3.8
-        }, 
-        "kg": {
-          "official": true, 
-          "percent": 1.5
-        }, 
-        "ln": {
-          "official": true, 
-          "percent": 3.1
-        }, 
-        "lol": {
-          "official": false, 
-          "percent": 0.61
-        }, 
-        "lu": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "lua": {
-          "official": true, 
-          "percent": 9.6
-        }, 
-        "rw": {
-          "official": false, 
-          "percent": 0.38
-        }, 
-        "sw": {
-          "official": true, 
-          "percent": 50.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CZ", 
-      "languages": {
-        "cs": {
-          "official": true, 
-          "percent": 98.0
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 15.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 0.49
-        }, 
-        "sk": {
-          "official": false, 
-          "percent": 16.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CY", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "el": {
-          "official": true, 
-          "percent": 95.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 73.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "tr": {
-          "official": true, 
-          "percent": 23.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CX", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 63.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CR", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CP", 
-      "languages": {
-        "und": {
-          "official": false, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CW", 
-      "languages": {
-        "es": {
-          "official": false, 
-          "percent": 3.8
-        }, 
-        "nl": {
-          "official": true, 
-          "percent": 8.0
-        }, 
-        "pap": {
-          "official": true, 
-          "percent": 81.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CV", 
-      "languages": {
-        "kea": {
-          "official": false, 
-          "percent": 91.0
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 76.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "CU", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SZ", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 80.0
-        }, 
-        "ss": {
-          "official": true, 
-          "percent": 58.0
-        }, 
-        "ts": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "zu": {
-          "official": false, 
-          "percent": 6.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SY", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 80.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 5.9
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 1.8
-        }, 
-        "ku": {
-          "official": false, 
-          "percent": 8.0
-        }, 
-        "syr": {
-          "official": false, 
-          "percent": 0.084
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SX", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 68.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 12.0
-        }, 
-        "nl": {
-          "official": true, 
-          "percent": 3.8
-        }, 
-        "vic": {
-          "official": false, 
-          "percent": 7.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KG", 
-      "languages": {
-        "ky": {
-          "official": true, 
-          "percent": 48.0
-        }, 
-        "ru": {
-          "official": true, 
-          "percent": 36.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KE", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 0.046
-        }, 
-        "dav": {
-          "official": false, 
-          "percent": 0.82
-        }, 
-        "ebu": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 19.0
-        }, 
-        "gu": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "guz": {
-          "official": false, 
-          "percent": 4.9
-        }, 
-        "kam": {
-          "official": false, 
-          "percent": 7.6
-        }, 
-        "ki": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "kln": {
-          "official": false, 
-          "percent": 7.6
-        }, 
-        "luo": {
-          "official": false, 
-          "percent": 9.8
-        }, 
-        "luy": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "mas": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "mer": {
-          "official": false, 
-          "percent": 4.0
-        }, 
-        "om": {
-          "official": false, 
-          "percent": 0.47
-        }, 
-        "pa": {
-          "official": false, 
-          "percent": 0.021
-        }, 
-        "pko": {
-          "official": false, 
-          "percent": 0.7
-        }, 
-        "saq": {
-          "official": false, 
-          "percent": 0.46
-        }, 
-        "so": {
-          "official": false, 
-          "percent": 1.3
-        }, 
-        "sw": {
-          "official": true, 
-          "percent": 66.0
-        }, 
-        "teo": {
-          "official": false, 
-          "percent": 0.74
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SS", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 27.0
-        }, 
-        "nus": {
-          "official": false, 
-          "percent": 5.6
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SR", 
-      "languages": {
-        "nl": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "srn": {
-          "official": false, 
-          "percent": 68.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 1.2
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KI", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "gil": {
-          "official": true, 
-          "percent": 60.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KH", 
-      "languages": {
-        "cja": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "kdt": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "km": {
-          "official": true, 
-          "percent": 89.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KN", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KM", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 66.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 56.0
-        }, 
-        "wni": {
-          "official": true, 
-          "percent": 34.0
-        }, 
-        "zdj": {
-          "official": true, 
-          "percent": 37.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ST", 
-      "languages": {
-        "pt": {
-          "official": true, 
-          "percent": 85.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SK", 
-      "languages": {
-        "cs": {
-          "official": false, 
-          "percent": 47.0
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 22.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 26.0
-        }, 
-        "hu": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 0.93
-        }, 
-        "sk": {
-          "official": true, 
-          "percent": 90.0
-        }, 
-        "uk": {
-          "official": false, 
-          "percent": 1.9
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KR", 
-      "languages": {
-        "ko": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SI", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 42.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 59.0
-        }, 
-        "hr": {
-          "official": false, 
-          "percent": 61.0
-        }, 
-        "hu": {
-          "official": false, 
-          "percent": 0.47
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 0.2
-        }, 
-        "sl": {
-          "official": true, 
-          "percent": 87.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KP", 
-      "languages": {
-        "ko": {
-          "official": true, 
-          "percent": 88.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KW", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SN", 
-      "languages": {
-        "bjt": {
-          "official": true, 
-          "percent": 0.61
-        }, 
-        "bsc": {
-          "official": true, 
-          "percent": 0.098
-        }, 
-        "dyo": {
-          "official": true, 
-          "percent": 2.6
-        }, 
-        "ff": {
-          "official": true, 
-          "percent": 21.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 39.0
-        }, 
-        "knf": {
-          "official": true, 
-          "percent": 0.21
-        }, 
-        "mey": {
-          "official": true, 
-          "percent": 0.049
-        }, 
-        "mfv": {
-          "official": true, 
-          "percent": 0.77
-        }, 
-        "sav": {
-          "official": true, 
-          "percent": 1.5
-        }, 
-        "snf": {
-          "official": true, 
-          "percent": 0.24
-        }, 
-        "srr": {
-          "official": true, 
-          "percent": 11.0
-        }, 
-        "tnr": {
-          "official": true, 
-          "percent": 0.023
-        }, 
-        "wo": {
-          "official": true, 
-          "percent": 70.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SM", 
-      "languages": {
-        "eo": {
-          "official": false, 
-          "percent": 0.89
-        }, 
-        "it": {
-          "official": true, 
-          "percent": 89.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SL", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 35.0
-        }, 
-        "kri": {
-          "official": false, 
-          "percent": 95.0
-        }, 
-        "men": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "tem": {
-          "official": false, 
-          "percent": 26.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SC", 
-      "languages": {
-        "crs": {
-          "official": false, 
-          "percent": 98.0
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 38.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 60.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KZ", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 6.4
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 15.0
-        }, 
-        "kk": {
-          "official": true, 
-          "percent": 64.0
-        }, 
-        "ru": {
-          "official": true, 
-          "percent": 72.0
-        }, 
-        "ug_Cyrl": {
-          "official": false, 
-          "percent": 2.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "KY", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "ml": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "ms": {
-          "official": true, 
-          "percent": 14.0
-        }, 
-        "pa": {
-          "official": false, 
-          "percent": 0.16
-        }, 
-        "ta": {
-          "official": true, 
-          "percent": 2.1
-        }, 
-        "zh": {
-          "official": true, 
-          "percent": 77.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SE", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 86.0
-        }, 
-        "fi": {
-          "official": true, 
-          "percent": 2.2
-        }, 
-        "fit": {
-          "official": false, 
-          "percent": 0.55
-        }, 
-        "ia": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "rmu": {
-          "official": false, 
-          "percent": 0.095
-        }, 
-        "se": {
-          "official": false, 
-          "percent": 0.33
-        }, 
-        "sma": {
-          "official": false, 
-          "percent": 0.003
-        }, 
-        "smj": {
-          "official": false, 
-          "percent": 0.015
-        }, 
-        "sv": {
-          "official": true, 
-          "percent": 95.0
-        }, 
-        "yi": {
-          "official": false, 
-          "percent": 0.03
-        }
-      }
-    }, 
-    {
-      "alpha_2": "SD", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 61.0
-        }, 
-        "bej": {
-          "official": false, 
-          "percent": 5.4
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 61.0
-        }, 
-        "fia": {
-          "official": false, 
-          "percent": 0.83
-        }, 
-        "fvr": {
-          "official": false, 
-          "percent": 2.7
-        }, 
-        "ha_Arab": {
-          "official": false, 
-          "percent": 1.8
-        }, 
-        "mls": {
-          "official": false, 
-          "percent": 0.99
-        }, 
-        "zag": {
-          "official": false, 
-          "percent": 0.51
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DO", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 0.075
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 78.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DM", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 94.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DJ", 
-      "languages": {
-        "aa": {
-          "official": false, 
-          "percent": 42.0
-        }, 
-        "ar": {
-          "official": true, 
-          "percent": 7.3
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 2.1
-        }, 
-        "so": {
-          "official": false, 
-          "percent": 41.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DK", 
-      "languages": {
-        "da": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "de": {
-          "official": true, 
-          "percent": 47.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 86.0
-        }, 
-        "fo": {
-          "official": false, 
-          "percent": 0.38
-        }, 
-        "jut": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "kl": {
-          "official": true, 
-          "percent": 0.12
-        }, 
-        "sv": {
-          "official": false, 
-          "percent": 13.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DE", 
-      "languages": {
-        "bar": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "da": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "de": {
-          "official": true, 
-          "percent": 91.0
-        }, 
-        "dsb": {
-          "official": false, 
-          "percent": 0.0087
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.38
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 64.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 18.0
-        }, 
-        "frr": {
+        {
+          "lang": "fi", 
           "official": false, 
           "percent": 0.012
         }, 
-        "frs": {
-          "official": false, 
-          "percent": 0.0025
-        }, 
-        "gsw": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "hr": {
-          "official": false, 
-          "percent": 0.79
-        }, 
-        "hsb": {
-          "official": false, 
-          "percent": 0.016
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "ksh": {
-          "official": false, 
-          "percent": 0.3
-        }, 
-        "ku": {
-          "official": false, 
-          "percent": 0.66
-        }, 
-        "nds": {
-          "official": false, 
-          "percent": 12.0
-        }, 
-        "nl": {
-          "official": false, 
-          "percent": 9.0
-        }, 
-        "pfl": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 0.29
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 6.0
-        }, 
-        "stq": {
-          "official": false, 
-          "percent": 0.0012
-        }, 
-        "swg": {
-          "official": false, 
-          "percent": 1.0
-        }, 
-        "tr": {
-          "official": false, 
-          "percent": 2.5
-        }, 
-        "vmf": {
-          "official": false, 
-          "percent": 6.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "YE", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 74.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 9.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "DZ", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 74.0
-        }, 
-        "arq": {
-          "official": false, 
-          "percent": 83.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 20.0
-        }, 
-        "kab": {
-          "official": false, 
-          "percent": 7.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "US", 
-      "languages": {
-        "cho": {
-          "official": false, 
-          "percent": 0.0033
-        }, 
-        "chr": {
-          "official": false, 
-          "percent": 0.0077
-        }, 
-        "dak": {
-          "official": false, 
-          "percent": 0.0059
-        }, 
-        "de": {
-          "official": false, 
-          "percent": 0.47
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 96.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 9.6
-        }, 
-        "esu": {
-          "official": false, 
-          "percent": 0.0062
-        }, 
-        "fil": {
-          "official": false, 
-          "percent": 0.42
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "frc": {
-          "official": false, 
-          "percent": 0.0084
-        }, 
-        "haw": {
-          "official": true, 
-          "percent": 0.0089
-        }, 
-        "ik": {
-          "official": false, 
-          "percent": 0.0024
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "ko": {
-          "official": false, 
-          "percent": 0.3
-        }, 
-        "lkt": {
-          "official": false, 
-          "percent": 0.0025
-        }, 
-        "mus": {
-          "official": false, 
-          "percent": 0.0012
-        }, 
-        "nv": {
-          "official": false, 
-          "percent": 0.05
-        }, 
-        "pdc": {
-          "official": false, 
-          "percent": 0.039
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "vi": {
-          "official": false, 
-          "percent": 0.34
-        }, 
-        "yi": {
-          "official": false, 
-          "percent": 0.049
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 0.69
-        }
-      }
-    }, 
-    {
-      "alpha_2": "UY", 
-      "languages": {
-        "es": {
-          "official": true, 
-          "percent": 88.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "YT", 
-      "languages": {
-        "buc": {
-          "official": false, 
-          "percent": 23.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 57.0
-        }, 
-        "sw": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "swb": {
-          "official": false, 
-          "percent": 88.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "UM", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LB", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 40.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 0.37
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 5.2
-        }, 
-        "ku_Arab": {
-          "official": false, 
-          "percent": 1.6
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LC", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 90.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LA", 
-      "languages": {
-        "kdt": {
-          "official": false, 
-          "percent": 0.96
-        }, 
-        "kjg": {
-          "official": false, 
-          "percent": 5.8
-        }, 
-        "lo": {
-          "official": true, 
-          "percent": 69.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TV", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 9.7
-        }, 
-        "tvl": {
-          "official": true, 
-          "percent": 90.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TW", 
-      "languages": {
-        "trv": {
-          "official": false, 
-          "percent": 0.02
-        }, 
-        "zh_Hant": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TT", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 88.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 0.34
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TR", 
-      "languages": {
-        "ab": {
-          "official": false, 
-          "percent": 0.0049
-        }, 
-        "ady": {
-          "official": false, 
-          "percent": 0.39
-        }, 
-        "ar": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "az": {
-          "official": false, 
-          "percent": 0.74
-        }, 
-        "az_Arab": {
-          "official": false, 
-          "percent": 0.65
-        }, 
-        "bg": {
-          "official": false, 
-          "percent": 0.42
-        }, 
-        "bgx": {
-          "official": false, 
-          "percent": 0.46
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.0049
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 0.056
-        }, 
-        "ka": {
-          "official": false, 
-          "percent": 0.056
-        }, 
-        "kbd": {
-          "official": false, 
-          "percent": 0.77
-        }, 
-        "kiu": {
-          "official": false, 
-          "percent": 0.19
-        }, 
-        "kk": {
-          "official": false, 
-          "percent": 0.0007
-        }, 
-        "ku": {
-          "official": false, 
-          "percent": 5.5
-        }, 
-        "ky_Latn": {
-          "official": false, 
-          "percent": 0.0014
-        }, 
-        "lzz": {
-          "official": false, 
-          "percent": 0.028
-        }, 
-        "sq": {
-          "official": false, 
-          "percent": 0.021
-        }, 
-        "sr_Latn": {
-          "official": false, 
-          "percent": 0.028
-        }, 
-        "tr": {
-          "official": true, 
-          "percent": 93.0
-        }, 
-        "tru": {
-          "official": false, 
-          "percent": 0.0037
-        }, 
-        "uz": {
-          "official": false, 
-          "percent": 0.0024
-        }, 
-        "zza": {
-          "official": false, 
-          "percent": 1.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LK", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 10.0
-        }, 
-        "si": {
-          "official": true, 
-          "percent": 68.0
-        }, 
-        "ta": {
-          "official": true, 
-          "percent": 15.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LI", 
-      "languages": {
-        "de": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "gsw": {
-          "official": true, 
-          "percent": 85.0
-        }, 
-        "wae": {
-          "official": false, 
-          "percent": 3.4
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LV", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 46.0
-        }, 
-        "ltg": {
-          "official": false, 
-          "percent": 8.9
-        }, 
-        "lv": {
-          "official": true, 
-          "percent": 61.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 38.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TO", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 28.0
-        }, 
-        "to": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LT", 
-      "languages": {
-        "de": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 38.0
-        }, 
-        "lt": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "ru": {
-          "official": false, 
-          "percent": 80.0
-        }, 
-        "sgs": {
-          "official": false, 
-          "percent": 0.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LU", 
-      "languages": {
-        "de": {
-          "official": true, 
-          "percent": 63.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 56.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 87.0
-        }, 
-        "lb": {
-          "official": true, 
-          "percent": 67.0
-        }, 
-        "pt": {
-          "official": false, 
-          "percent": 16.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LR", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 83.0
-        }, 
-        "kpe": {
-          "official": false, 
-          "percent": 14.0
-        }, 
-        "men": {
-          "official": false, 
-          "percent": 0.48
-        }, 
-        "vai": {
-          "official": false, 
-          "percent": 2.6
-        }, 
-        "vai_Latn": {
-          "official": false, 
-          "percent": 0.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LS", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 27.0
-        }, 
-        "ss": {
-          "official": false, 
-          "percent": 2.4
-        }, 
-        "st": {
-          "official": true, 
-          "percent": 98.0
-        }, 
-        "xh": {
-          "official": false, 
-          "percent": 0.99
-        }, 
-        "zu": {
-          "official": false, 
-          "percent": 14.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TH", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 27.0
-        }, 
-        "kdt": {
-          "official": false, 
-          "percent": 0.48
-        }, 
-        "kxm": {
-          "official": false, 
-          "percent": 1.7
-        }, 
-        "lcp": {
-          "official": false, 
-          "percent": 0.01
-        }, 
-        "lwl": {
-          "official": false, 
-          "percent": 0.01
-        }, 
-        "mfa": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "mnw": {
-          "official": false, 
-          "percent": 0.17
-        }, 
-        "nod": {
-          "official": false, 
-          "percent": 9.6
-        }, 
-        "shn": {
-          "official": false, 
-          "percent": 0.096
-        }, 
-        "sou": {
-          "official": false, 
-          "percent": 8.0
-        }, 
-        "th": {
-          "official": true, 
-          "percent": 80.0
-        }, 
-        "tts": {
-          "official": false, 
-          "percent": 24.0
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 1.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TF", 
-      "languages": {
-        "fr": {
-          "official": false, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TG", 
-      "languages": {
-        "ee": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 61.0
-        }, 
-        "ife": {
-          "official": false, 
-          "percent": 1.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TD", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 17.0
-        }, 
-        "fr": {
-          "official": true, 
-          "percent": 26.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "TC", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 98.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "LY", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 74.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VA", 
-      "languages": {
-        "it": {
-          "official": true, 
-          "percent": 82.0
-        }, 
-        "la": {
-          "official": false, 
-          "percent": 82.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AC", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VC", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 96.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AE", 
-      "languages": {
-        "ar": {
-          "official": true, 
-          "percent": 78.0
-        }, 
-        "bal": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "fa": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "ml": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "ps": {
-          "official": false, 
-          "percent": 2.9
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AD", 
-      "languages": {
-        "ca": {
-          "official": true, 
-          "percent": 51.0
-        }, 
-        "es": {
-          "official": false, 
-          "percent": 43.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 6.7
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AG", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 86.0
-        }, 
-        "pt": {
-          "official": false, 
-          "percent": 1.7
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AF", 
-      "languages": {
-        "bal": {
-          "official": true, 
-          "percent": 0.67
-        }, 
-        "bgn": {
-          "official": false, 
-          "percent": 0.63
-        }, 
-        "fa": {
-          "official": true, 
-          "percent": 50.0
-        }, 
-        "haz": {
-          "official": false, 
-          "percent": 5.9
-        }, 
-        "kk_Arab": {
-          "official": false, 
-          "percent": 0.0059
-        }, 
-        "prd": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "ps": {
-          "official": true, 
-          "percent": 43.0
-        }, 
-        "tk": {
-          "official": true, 
-          "percent": 1.7
-        }, 
-        "ug": {
-          "official": false, 
-          "percent": 0.0088
-        }, 
-        "uz_Arab": {
-          "official": true, 
-          "percent": 4.7
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AI", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 95.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "VI", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 75.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IS", 
-      "languages": {
-        "da": {
-          "official": false, 
-          "percent": 0.66
-        }, 
-        "is": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IR", 
-      "languages": {
-        "ar": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "az_Arab": {
-          "official": false, 
-          "percent": 24.0
-        }, 
-        "bal": {
-          "official": false, 
-          "percent": 2.0
-        }, 
-        "bgn": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "bqi": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "ckb": {
-          "official": false, 
-          "percent": 3.9
-        }, 
-        "fa": {
-          "official": true, 
-          "percent": 75.0
-        }, 
-        "gbz": {
-          "official": false, 
-          "percent": 0.0098
-        }, 
-        "glk": {
-          "official": false, 
-          "percent": 4.6
-        }, 
-        "hy": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "ka": {
-          "official": false, 
-          "percent": 0.071
-        }, 
-        "kk_Arab": {
-          "official": false, 
-          "percent": 0.0037
-        }, 
-        "lki": {
-          "official": false, 
-          "percent": 0.76
-        }, 
-        "lrc": {
-          "official": false, 
-          "percent": 2.1
-        }, 
-        "luz": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "mzn": {
-          "official": false, 
-          "percent": 5.0
-        }, 
-        "prd": {
-          "official": false, 
-          "percent": 0.5
-        }, 
-        "ps": {
-          "official": false, 
-          "percent": 0.16
-        }, 
-        "rmt": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "sdh": {
-          "official": false, 
-          "percent": 3.7
-        }, 
-        "tk": {
-          "official": false, 
-          "percent": 2.8
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AM", 
-      "languages": {
-        "az": {
-          "official": false, 
-          "percent": 0.0
-        }, 
-        "hy": {
-          "official": true, 
-          "percent": 98.0
-        }, 
-        "ku": {
-          "official": false, 
-          "percent": 3.3
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AL", 
-      "languages": {
-        "el": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "mk": {
-          "official": false, 
-          "percent": 0.47
-        }, 
-        "sq": {
-          "official": true, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AO", 
-      "languages": {
-        "kmb": {
-          "official": false, 
-          "percent": 25.0
-        }, 
-        "ln": {
-          "official": false, 
-          "percent": 0.67
-        }, 
-        "pt": {
-          "official": true, 
-          "percent": 67.0
-        }, 
-        "umb": {
-          "official": false, 
-          "percent": 29.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AQ", 
-      "languages": {
-        "und": {
-          "official": false, 
-          "percent": 100.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AS", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 97.0
-        }, 
-        "sm": {
-          "official": true, 
-          "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AR", 
-      "languages": {
-        "cy": {
-          "official": false, 
-          "percent": 0.066
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 7.0
-        }, 
-        "es": {
-          "official": true, 
-          "percent": 100.0
-        }, 
-        "gn": {
-          "official": false, 
-          "percent": 0.047
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AU", 
-      "languages": {
-        "en": {
-          "official": true, 
-          "percent": 96.0
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "wbp": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "zh_Hant": {
-          "official": false, 
-          "percent": 2.1
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AT", 
-      "languages": {
-        "bar": {
-          "official": false, 
-          "percent": 95.0
-        }, 
-        "de": {
-          "official": true, 
-          "percent": 97.0
-        }, 
-        "en": {
-          "official": false, 
-          "percent": 73.0
-        }, 
-        "fr": {
-          "official": false, 
-          "percent": 11.0
-        }, 
-        "hr": {
-          "official": true, 
-          "percent": 1.2
-        }, 
-        "hu": {
-          "official": true, 
-          "percent": 0.27
-        }, 
-        "it": {
-          "official": false, 
-          "percent": 9.0
-        }, 
-        "sl": {
-          "official": true, 
-          "percent": 0.37
-        }
-      }
-    }, 
-    {
-      "alpha_2": "AW", 
-      "languages": {
-        "en": {
-          "official": false, 
-          "percent": 2.6
-        }, 
-        "nl": {
-          "official": true, 
-          "percent": 97.0
-        }, 
-        "pap": {
-          "official": true, 
-          "percent": 61.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IN", 
-      "languages": {
-        "as": {
-          "official": true, 
-          "percent": 1.3
-        }, 
-        "awa": {
-          "official": false, 
-          "percent": 1.9
-        }, 
-        "bfq": {
-          "official": false, 
-          "percent": 0.023
-        }, 
-        "bft": {
-          "official": false, 
-          "percent": 0.0062
-        }, 
-        "bfy": {
-          "official": false, 
-          "percent": 0.037
-        }, 
-        "bgc": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "bhb": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "bhi": {
-          "official": false, 
-          "percent": 0.092
-        }, 
-        "bho": {
-          "official": false, 
-          "percent": 2.3
-        }, 
-        "bjj": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "bn": {
-          "official": true, 
-          "percent": 8.1
-        }, 
-        "bo": {
-          "official": false, 
-          "percent": 0.011
-        }, 
-        "bpy": {
-          "official": false, 
-          "percent": 0.0068
-        }, 
-        "bra": {
-          "official": false, 
-          "percent": 0.0041
-        }, 
-        "brx": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "btv": {
-          "official": false, 
-          "percent": 0.0026
-        }, 
-        "ccp": {
-          "official": false, 
-          "percent": 0.028
-        }, 
-        "dcc": {
-          "official": false, 
-          "percent": 0.99
-        }, 
-        "doi": {
-          "official": false, 
-          "percent": 0.19
-        }, 
-        "dv": {
-          "official": false, 
-          "percent": 0.0004
-        }, 
-        "dz": {
-          "official": false, 
-          "percent": 0.0002
-        }, 
-        "en": {
-          "official": true, 
-          "percent": 19.0
-        }, 
-        "gbm": {
-          "official": false, 
-          "percent": 0.27
-        }, 
-        "gom": {
-          "official": false, 
-          "percent": 0.32
-        }, 
-        "gon": {
-          "official": false, 
-          "percent": 0.24
-        }, 
-        "grt": {
-          "official": false, 
-          "percent": 0.053
-        }, 
-        "gu": {
-          "official": true, 
-          "percent": 4.5
-        }, 
-        "hi": {
-          "official": true, 
-          "percent": 41.0
-        }, 
-        "hne": {
-          "official": false, 
-          "percent": 1.1
-        }, 
-        "hoc": {
-          "official": false, 
-          "percent": 0.099
-        }, 
-        "hoj": {
-          "official": false, 
-          "percent": 0.082
-        }, 
-        "kfr": {
-          "official": false, 
-          "percent": 0.075
-        }, 
-        "kfy": {
-          "official": false, 
-          "percent": 0.22
-        }, 
-        "kha": {
-          "official": true, 
-          "percent": 0.08
-        }, 
-        "khn": {
-          "official": false, 
-          "percent": 0.15
-        }, 
-        "kht": {
-          "official": false, 
-          "percent": 0.0007
-        }, 
-        "kn": {
-          "official": true, 
-          "percent": 3.7
-        }, 
-        "kok": {
-          "official": true, 
-          "percent": 0.37
-        }, 
-        "kru": {
-          "official": false, 
-          "percent": 0.19
-        }, 
-        "ks": {
-          "official": true, 
-          "percent": 0.41
-        }, 
-        "lah": {
-          "official": false, 
-          "percent": 0.0025
-        }, 
-        "lep": {
+        {
+          "lang": "sr_Latn", 
           "official": false, 
           "percent": 0.0035
         }, 
-        "lif": {
+        {
+          "lang": "vep", 
           "official": false, 
-          "percent": 0.0026
+          "percent": 0.0025
         }, 
-        "lmn": {
+        {
+          "lang": "mn", 
           "official": false, 
-          "percent": 0.27
+          "percent": 0.0015
         }, 
-        "mag": {
+        {
+          "lang": "izh", 
           "official": false, 
-          "percent": 1.2
+          "percent": 0.0001
         }, 
-        "mai": {
-          "official": true, 
-          "percent": 1.2
-        }, 
-        "ml": {
-          "official": true, 
-          "percent": 3.2
-        }, 
-        "mni": {
+        {
+          "lang": "cu", 
           "official": false, 
-          "percent": 0.11
+          "percent": 0.0
         }, 
-        "mr": {
-          "official": true, 
-          "percent": 7.0
-        }, 
-        "mtr": {
+        {
+          "lang": "vot", 
           "official": false, 
-          "percent": 0.098
-        }, 
-        "mwr": {
-          "official": false, 
-          "percent": 1.2
-        }, 
-        "ne": {
-          "official": true, 
-          "percent": 0.56
-        }, 
-        "njo": {
-          "official": false, 
-          "percent": 0.023
-        }, 
-        "noe": {
-          "official": false, 
-          "percent": 0.13
-        }, 
-        "or": {
-          "official": true, 
-          "percent": 3.2
-        }, 
-        "pa": {
-          "official": true, 
-          "percent": 2.8
-        }, 
-        "raj": {
-          "official": false, 
-          "percent": 0.1
-        }, 
-        "ria": {
-          "official": false, 
-          "percent": 0.013
-        }, 
-        "rkt": {
-          "official": false, 
-          "percent": 0.44
-        }, 
-        "sa": {
-          "official": true, 
-          "percent": 0.0012
-        }, 
-        "sat": {
-          "official": true, 
-          "percent": 0.55
-        }, 
-        "saz": {
-          "official": false, 
-          "percent": 0.029
-        }, 
-        "sck": {
-          "official": false, 
-          "percent": 0.18
-        }, 
-        "sd": {
-          "official": true, 
-          "percent": 0.26
-        }, 
-        "sd_Deva": {
-          "official": true, 
-          "percent": 0.026
-        }, 
-        "srx": {
-          "official": false, 
-          "percent": 0.035
-        }, 
-        "swv": {
-          "official": false, 
-          "percent": 0.28
-        }, 
-        "ta": {
-          "official": true, 
-          "percent": 5.9
-        }, 
-        "tcy": {
-          "official": false, 
-          "percent": 0.15
-        }, 
-        "te": {
-          "official": true, 
-          "percent": 7.2
-        }, 
-        "unr": {
-          "official": false, 
-          "percent": 0.095
-        }, 
-        "unx": {
-          "official": false, 
-          "percent": 0.048
-        }, 
-        "ur": {
-          "official": true, 
-          "percent": 5.0
-        }, 
-        "wbq": {
-          "official": false, 
-          "percent": 0.18
-        }, 
-        "wbr": {
-          "official": false, 
-          "percent": 0.15
-        }, 
-        "wtm": {
-          "official": false, 
-          "percent": 0.46
-        }, 
-        "xnr": {
-          "official": false, 
-          "percent": 0.16
+          "percent": 0.0
         }
-      }
+      ]
     }, 
     {
-      "alpha_2": "AX", 
-      "languages": {
-        "sv": {
+      "alpha_2": "RW", 
+      "languages": [
+        {
+          "lang": "rw", 
+          "official": true, 
+          "percent": 77.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 0.019
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "RS", 
+      "languages": [
+        {
+          "lang": "sr", 
           "official": true, 
           "percent": 99.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "IC", 
-      "languages": {
-        "es": {
+        }, 
+        {
+          "lang": "sr_Latn", 
           "official": true, 
-          "percent": 98.0
+          "percent": 99.0
+        }, 
+        {
+          "lang": "sq", 
+          "official": false, 
+          "percent": 19.0
+        }, 
+        {
+          "lang": "hu", 
+          "official": true, 
+          "percent": 4.8
+        }, 
+        {
+          "lang": "ro", 
+          "official": true, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "hr", 
+          "official": true, 
+          "percent": 0.93
+        }, 
+        {
+          "lang": "sk", 
+          "official": true, 
+          "percent": 0.85
+        }, 
+        {
+          "lang": "uk", 
+          "official": true, 
+          "percent": 0.0
         }
-      }
+      ]
     }, 
     {
-      "alpha_2": "AZ", 
-      "languages": {
-        "az": {
+      "alpha_2": "TL", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 59.0
+        }, 
+        {
+          "lang": "tet", 
+          "official": true, 
+          "percent": 59.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "RE", 
+      "languages": [
+        {
+          "lang": "fr", 
           "official": true, 
           "percent": 89.0
         }, 
-        "az_Cyrl": {
-          "official": true, 
-          "percent": 9.9
-        }, 
-        "ku": {
+        {
+          "lang": "rcf", 
           "official": false, 
-          "percent": 0.24
+          "percent": 71.0
         }, 
-        "tkr": {
+        {
+          "lang": "ta", 
           "official": false, 
-          "percent": 0.16
-        }, 
-        "tly": {
-          "official": false, 
-          "percent": 9.8
-        }, 
-        "ttt": {
-          "official": false, 
-          "percent": 0.22
+          "percent": 15.0
         }
-      }
+      ]
     }, 
     {
-      "alpha_2": "IE", 
-      "languages": {
-        "en": {
+      "alpha_2": "TM", 
+      "languages": [
+        {
+          "lang": "tk", 
           "official": true, 
-          "percent": 98.0
+          "percent": 70.0
         }, 
-        "fr": {
-          "official": false, 
-          "percent": 17.0
-        }, 
-        "ga": {
-          "official": true, 
-          "percent": 22.0
-        }
-      }
-    }, 
-    {
-      "alpha_2": "ID", 
-      "languages": {
-        "ace": {
-          "official": false, 
-          "percent": 1.4
-        }, 
-        "aoz": {
-          "official": false, 
-          "percent": 0.27
-        }, 
-        "ban": {
-          "official": false, 
-          "percent": 1.8
-        }, 
-        "bbc": {
-          "official": false, 
-          "percent": 0.92
-        }, 
-        "bew": {
-          "official": false, 
-          "percent": 2.1
-        }, 
-        "bjn": {
-          "official": false, 
-          "percent": 1.5
-        }, 
-        "bug": {
-          "official": false, 
-          "percent": 1.6
-        }, 
-        "gay": {
-          "official": false, 
-          "percent": 0.12
-        }, 
-        "gor": {
-          "official": false, 
-          "percent": 0.41
-        }, 
-        "id": {
-          "official": true, 
-          "percent": 64.0
-        }, 
-        "jv": {
-          "official": false, 
-          "percent": 34.0
-        }, 
-        "kge": {
-          "official": false, 
-          "percent": 0.32
-        }, 
-        "kvr": {
-          "official": false, 
-          "percent": 0.14
-        }, 
-        "lbw": {
-          "official": false, 
-          "percent": 0.13
-        }, 
-        "ljp": {
-          "official": false, 
-          "percent": 0.69
-        }, 
-        "mad": {
-          "official": false, 
-          "percent": 6.3
-        }, 
-        "mak": {
-          "official": false, 
-          "percent": 0.73
-        }, 
-        "mdr": {
-          "official": false, 
-          "percent": 0.092
-        }, 
-        "min": {
-          "official": false, 
-          "percent": 3.0
-        }, 
-        "ms_Arab": {
-          "official": false, 
-          "percent": 4.6
-        }, 
-        "mwv": {
-          "official": false, 
-          "percent": 0.024
-        }, 
-        "nij": {
-          "official": false, 
-          "percent": 0.37
-        }, 
-        "rej": {
-          "official": false, 
-          "percent": 0.46
-        }, 
-        "rob": {
-          "official": false, 
-          "percent": 0.11
-        }, 
-        "sas": {
-          "official": false, 
-          "percent": 0.97
-        }, 
-        "sly": {
-          "official": false, 
-          "percent": 0.054
-        }, 
-        "su": {
+        {
+          "lang": "ru", 
           "official": false, 
           "percent": 12.0
         }, 
-        "sxn": {
+        {
+          "lang": "uz", 
           "official": false, 
-          "percent": 0.092
+          "percent": 9.0
         }, 
-        "zh_Hant": {
+        {
+          "lang": "ku", 
           "official": false, 
-          "percent": 0.92
+          "percent": 0.41
         }
-      }
+      ]
     }, 
     {
-      "alpha_2": "UA", 
-      "languages": {
-        "be": {
-          "official": false, 
-          "percent": 0.83
-        }, 
-        "bg": {
-          "official": false, 
-          "percent": 0.49
-        }, 
-        "crh": {
-          "official": false, 
-          "percent": 0.56
-        }, 
-        "el": {
-          "official": false, 
-          "percent": 0.016
-        }, 
-        "hu": {
-          "official": false, 
-          "percent": 0.37
-        }, 
-        "pl": {
-          "official": false, 
-          "percent": 2.4
-        }, 
-        "ro": {
-          "official": false, 
-          "percent": 0.52
-        }, 
-        "ru": {
+      "alpha_2": "TJ", 
+      "languages": [
+        {
+          "lang": "tg", 
           "official": true, 
-          "percent": 46.0
+          "percent": 100.0
         }, 
-        "rue": {
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 0.78
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.012
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "RO", 
+      "languages": [
+        {
+          "lang": "ro", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 31.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 10.0
+        }, 
+        {
+          "lang": "hu", 
+          "official": false, 
+          "percent": 6.6
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "sr_Latn", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "bg", 
+          "official": false, 
+          "percent": 0.031
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.019
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 0.013
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TK", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "tkl", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GW", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "knf", 
+          "official": false, 
+          "percent": 2.6
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GU", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 91.0
+        }, 
+        {
+          "lang": "ch", 
+          "official": true, 
+          "percent": 22.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GT", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "quc", 
+          "official": true, 
+          "percent": 7.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GS", 
+      "languages": [
+        {
+          "lang": "und", 
+          "official": false, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GR", 
+      "languages": [
+        {
+          "lang": "el", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 51.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 9.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "pnt", 
+          "official": false, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "mk", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "tr", 
           "official": false, 
           "percent": 1.2
         }, 
-        "tr": {
+        {
+          "lang": "bg", 
           "official": false, 
-          "percent": 0.42
+          "percent": 0.27
         }, 
-        "uk": {
-          "official": true, 
-          "percent": 65.0
-        }, 
-        "yi": {
+        {
+          "lang": "sq", 
           "official": false, 
-          "percent": 1.3
+          "percent": 0.093
+        }, 
+        {
+          "lang": "tsd", 
+          "official": false, 
+          "percent": 0.0019
         }
-      }
+      ]
     }, 
     {
-      "alpha_2": "QA", 
-      "languages": {
-        "ar": {
+      "alpha_2": "GQ", 
+      "languages": [
+        {
+          "lang": "es", 
           "official": true, 
-          "percent": 89.0
+          "percent": 87.0
         }, 
-        "fa": {
+        {
+          "lang": "fan", 
           "official": false, 
-          "percent": 11.0
+          "percent": 51.0
         }, 
-        "ml": {
-          "official": false, 
-          "percent": 0.28
-        }
-      }
-    }, 
-    {
-      "alpha_2": "MZ", 
-      "languages": {
-        "mgh": {
-          "official": false, 
-          "percent": 4.5
-        }, 
-        "ndc": {
-          "official": false, 
-          "percent": 9.9
-        }, 
-        "ngl": {
-          "official": false, 
-          "percent": 6.8
-        }, 
-        "ny": {
-          "official": false, 
-          "percent": 2.6
-        }, 
-        "pt": {
+        {
+          "lang": "fr", 
           "official": true, 
-          "percent": 27.0
+          "percent": 8.8
         }, 
-        "rng": {
-          "official": false, 
-          "percent": 3.4
-        }, 
-        "seh": {
-          "official": false, 
-          "percent": 4.6
-        }, 
-        "sw": {
-          "official": false, 
-          "percent": 0.035
-        }, 
-        "ts": {
+        {
+          "lang": "bvb", 
           "official": false, 
           "percent": 7.9
         }, 
-        "vmw": {
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 0.0001
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GP", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 90.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "JP", 
+      "languages": [
+        {
+          "lang": "ja", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "ryu", 
+          "official": false, 
+          "percent": 0.77
+        }, 
+        {
+          "lang": "ko", 
+          "official": false, 
+          "percent": 0.52
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GY", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GF", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 77.0
+        }, 
+        {
+          "lang": "gcr", 
+          "official": false, 
+          "percent": 26.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 2.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GE", 
+      "languages": [
+        {
+          "lang": "ka", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "xmf", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 9.0
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "ab", 
+          "official": true, 
+          "percent": 2.2
+        }, 
+        {
+          "lang": "os", 
+          "official": true, 
+          "percent": 2.2
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 0.89
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GD", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 96.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GB", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 19.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "sco", 
+          "official": false, 
+          "percent": 2.7
+        }, 
+        {
+          "lang": "pa", 
+          "official": false, 
+          "percent": 0.79
+        }, 
+        {
+          "lang": "cy", 
+          "official": true, 
+          "percent": 0.77
+        }, 
+        {
+          "lang": "bn", 
+          "official": false, 
+          "percent": 0.67
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 0.54
+        }, 
+        {
+          "lang": "syl", 
+          "official": false, 
+          "percent": 0.51
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "ks", 
+          "official": false, 
+          "percent": 0.19
+        }, 
+        {
+          "lang": "gd", 
+          "official": true, 
+          "percent": 0.099
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 0.049
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 0.035
+        }, 
+        {
+          "lang": "ga", 
+          "official": true, 
+          "percent": 0.026
+        }, 
+        {
+          "lang": "kw", 
+          "official": false, 
+          "percent": 0.0031
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GA", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 63.0
+        }, 
+        {
+          "lang": "puu", 
+          "official": false, 
+          "percent": 9.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SV", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 89.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GN", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 29.0
+        }, 
+        {
+          "lang": "ff", 
+          "official": false, 
+          "percent": 26.0
+        }, 
+        {
+          "lang": "man_Nkoo", 
+          "official": false, 
+          "percent": 23.0
+        }, 
+        {
+          "lang": "sus", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "nqo", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "kpe", 
+          "official": false, 
+          "percent": 3.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GM", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 40.0
+        }, 
+        {
+          "lang": "man", 
+          "official": false, 
+          "percent": 29.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GL", 
+      "languages": [
+        {
+          "lang": "kl", 
+          "official": true, 
+          "percent": 84.0
+        }, 
+        {
+          "lang": "da", 
+          "official": false, 
+          "percent": 14.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GI", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 50.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "GH", 
+      "languages": [
+        {
+          "lang": "ak", 
+          "official": true, 
+          "percent": 39.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "ee", 
+          "official": true, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "abr", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "gur", 
+          "official": false, 
+          "percent": 3.5
+        }, 
+        {
+          "lang": "ada", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "gaa", 
+          "official": true, 
+          "percent": 2.8
+        }, 
+        {
+          "lang": "nzi", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "ha", 
+          "official": false, 
+          "percent": 0.87
+        }, 
+        {
+          "lang": "saf", 
+          "official": false, 
+          "percent": 0.015
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "OM", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 81.0
+        }, 
+        {
+          "lang": "bal", 
+          "official": false, 
+          "percent": 4.9
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 0.94
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TN", 
+      "languages": [
+        {
+          "lang": "aeb", 
+          "official": false, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 74.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "JO", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 45.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TA", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 99.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HR", 
+      "languages": [
+        {
+          "lang": "hr", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 49.0
+        }, 
+        {
+          "lang": "it", 
+          "official": true, 
+          "percent": 1.6
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HT", 
+      "languages": [
+        {
+          "lang": "ht", 
+          "official": true, 
+          "percent": 81.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 4.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HU", 
+      "languages": [
+        {
+          "lang": "hu", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "ro", 
+          "official": false, 
+          "percent": 0.99
+        }, 
+        {
+          "lang": "hr", 
+          "official": false, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "sk", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "sl", 
+          "official": false, 
+          "percent": 0.051
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HK", 
+      "languages": [
+        {
+          "lang": "zh_Hant", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "yue", 
+          "official": false, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 51.0
+        }, 
+        {
+          "lang": "zh", 
+          "official": false, 
+          "percent": 5.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HN", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 78.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 0.44
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "HM", 
+      "languages": [
+        {
+          "lang": "und", 
+          "official": false, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VE", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 82.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PR", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 87.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 49.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PS", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PW", 
+      "languages": [
+        {
+          "lang": "pau", 
+          "official": true, 
+          "percent": 74.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 8.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PT", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 96.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 10.0
+        }, 
+        {
+          "lang": "gl", 
+          "official": false, 
+          "percent": 0.14
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SJ", 
+      "languages": [
+        {
+          "lang": "nb", 
+          "official": true, 
+          "percent": 56.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 45.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PY", 
+      "languages": [
+        {
+          "lang": "gn", 
+          "official": true, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 3.2
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 2.9
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IQ", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 68.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 35.0
+        }, 
+        {
+          "lang": "ckb", 
+          "official": true, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "az_Arab", 
+          "official": true, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 0.87
+        }, 
+        {
+          "lang": "lrc", 
+          "official": false, 
+          "percent": 0.61
+        }, 
+        {
+          "lang": "syr", 
+          "official": false, 
+          "percent": 0.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PA", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 69.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 0.16
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PF", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "ty", 
+          "official": true, 
+          "percent": 31.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 7.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PG", 
+      "languages": [
+        {
+          "lang": "tpi", 
+          "official": true, 
+          "percent": 71.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 50.0
+        }, 
+        {
+          "lang": "ho", 
+          "official": true, 
+          "percent": 2.1
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PE", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 73.0
+        }, 
+        {
+          "lang": "qu", 
+          "official": true, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "ay", 
+          "official": false, 
+          "percent": 1.6
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PK", 
+      "languages": [
+        {
+          "lang": "ur", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "pa_Arab", 
+          "official": false, 
+          "percent": 70.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 50.0
+        }, 
+        {
+          "lang": "lah", 
+          "official": false, 
+          "percent": 40.0
+        }, 
+        {
+          "lang": "ps", 
+          "official": false, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "sd", 
+          "official": false, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "skr", 
+          "official": false, 
+          "percent": 9.1
+        }, 
+        {
+          "lang": "bal", 
+          "official": false, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "brh", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "hno", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 0.66
+        }, 
+        {
+          "lang": "bgn", 
+          "official": false, 
+          "percent": 0.57
+        }, 
+        {
+          "lang": "hnd", 
+          "official": false, 
+          "percent": 0.41
+        }, 
+        {
+          "lang": "tg_Arab", 
+          "official": false, 
+          "percent": 0.33
+        }, 
+        {
+          "lang": "gju", 
+          "official": false, 
+          "percent": 0.2
+        }, 
+        {
+          "lang": "bft", 
+          "official": false, 
+          "percent": 0.18
+        }, 
+        {
+          "lang": "kvx", 
+          "official": false, 
+          "percent": 0.16
+        }, 
+        {
+          "lang": "khw", 
+          "official": false, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "mvy", 
+          "official": false, 
+          "percent": 0.14
+        }, 
+        {
+          "lang": "kxp", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "gjk", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "ks", 
+          "official": false, 
+          "percent": 0.069
+        }, 
+        {
+          "lang": "btv", 
+          "official": false, 
+          "percent": 0.019
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PH", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "fil", 
+          "official": true, 
+          "percent": 60.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 31.0
+        }, 
+        {
+          "lang": "ceb", 
+          "official": true, 
+          "percent": 24.0
+        }, 
+        {
+          "lang": "ilo", 
+          "official": true, 
+          "percent": 9.6
+        }, 
+        {
+          "lang": "hil", 
+          "official": true, 
+          "percent": 8.4
+        }, 
+        {
+          "lang": "bik", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "war", 
+          "official": true, 
+          "percent": 2.9
+        }, 
+        {
+          "lang": "bhk", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "pam", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "pag", 
+          "official": true, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "mdh", 
+          "official": true, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "tsg", 
+          "official": true, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 0.73
+        }, 
+        {
+          "lang": "cps", 
+          "official": false, 
+          "percent": 0.67
+        }, 
+        {
+          "lang": "krj", 
+          "official": false, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "bto", 
+          "official": false, 
+          "percent": 0.28
+        }, 
+        {
+          "lang": "hnn", 
+          "official": false, 
+          "percent": 0.016
+        }, 
+        {
+          "lang": "tbw", 
+          "official": false, 
+          "percent": 0.0096
+        }, 
+        {
+          "lang": "bku", 
+          "official": false, 
+          "percent": 0.0077
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PN", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 85.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PL", 
+      "languages": [
+        {
+          "lang": "pl", 
+          "official": true, 
+          "percent": 96.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 33.0
+        }, 
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 19.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "szl", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "be", 
+          "official": false, 
+          "percent": 0.58
+        }, 
+        {
+          "lang": "uk", 
+          "official": false, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "csb", 
+          "official": true, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "sli", 
+          "official": false, 
+          "percent": 0.031
+        }, 
+        {
+          "lang": "lt", 
+          "official": true, 
+          "percent": 0.021
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "PM", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 92.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 3.4
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ZM", 
+      "languages": [
+        {
+          "lang": "bem", 
+          "official": false, 
+          "percent": 31.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 16.0
+        }, 
+        {
+          "lang": "ny", 
+          "official": false, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "loz", 
+          "official": false, 
+          "percent": 6.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "EH", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "EE", 
+      "languages": [
+        {
+          "lang": "et", 
+          "official": true, 
+          "percent": 71.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 56.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 50.0
+        }, 
+        {
+          "lang": "fi", 
+          "official": false, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "vro", 
+          "official": false, 
+          "percent": 5.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "EG", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 94.0
+        }, 
+        {
+          "lang": "arz", 
+          "official": false, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 35.0
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.061
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "EA", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ZA", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 31.0
+        }, 
+        {
+          "lang": "zu", 
+          "official": true, 
+          "percent": 24.0
+        }, 
+        {
+          "lang": "xh", 
+          "official": true, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "af", 
+          "official": true, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "nso", 
+          "official": true, 
+          "percent": 9.4
+        }, 
+        {
+          "lang": "tn", 
+          "official": true, 
+          "percent": 8.2
+        }, 
+        {
+          "lang": "st", 
+          "official": true, 
+          "percent": 7.9
+        }, 
+        {
+          "lang": "ts", 
+          "official": true, 
+          "percent": 4.4
+        }, 
+        {
+          "lang": "ss", 
+          "official": true, 
+          "percent": 2.7
+        }, 
+        {
+          "lang": "ve", 
+          "official": true, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "hi", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "nr", 
+          "official": true, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "sw", 
+          "official": false, 
+          "percent": 0.0018
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "EC", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 96.0
+        }, 
+        {
+          "lang": "qu", 
+          "official": true, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "qug", 
+          "official": false, 
+          "percent": 5.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IT", 
+      "languages": [
+        {
+          "lang": "it", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 34.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 6.3
+        }, 
+        {
+          "lang": "sc", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "vec", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "nap", 
+          "official": false, 
+          "percent": 0.97
+        }, 
+        {
+          "lang": "lij", 
+          "official": false, 
+          "percent": 0.86
+        }, 
+        {
+          "lang": "scn", 
+          "official": false, 
+          "percent": 0.82
+        }, 
+        {
+          "lang": "sdc", 
+          "official": false, 
+          "percent": 0.17
+        }, 
+        {
+          "lang": "sl", 
+          "official": false, 
+          "percent": 0.17
+        }, 
+        {
+          "lang": "fur", 
+          "official": false, 
+          "percent": 0.06
+        }, 
+        {
+          "lang": "egl", 
+          "official": false, 
+          "percent": 0.05
+        }, 
+        {
+          "lang": "ca", 
+          "official": false, 
+          "percent": 0.035
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.035
+        }, 
+        {
+          "lang": "lmo", 
+          "official": false, 
+          "percent": 0.03
+        }, 
+        {
+          "lang": "pms", 
+          "official": false, 
+          "percent": 0.0099
+        }, 
+        {
+          "lang": "hr", 
+          "official": false, 
+          "percent": 0.0056
+        }, 
+        {
+          "lang": "rgn", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VN", 
+      "languages": [
+        {
+          "lang": "vi", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "cjm", 
+          "official": false, 
+          "percent": 0.089
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ZZ", 
+      "languages": []
+    }, 
+    {
+      "alpha_2": "SB", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "rug", 
+          "official": false, 
+          "percent": 1.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ET", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 43.0
+        }, 
+        {
+          "lang": "am", 
+          "official": true, 
+          "percent": 33.0
+        }, 
+        {
+          "lang": "om", 
+          "official": false, 
+          "percent": 32.0
+        }, 
+        {
+          "lang": "so", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "ti", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "sid", 
+          "official": false, 
+          "percent": 3.5
+        }, 
+        {
+          "lang": "wal", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "aa", 
+          "official": false, 
+          "percent": 1.4
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SO", 
+      "languages": [
+        {
+          "lang": "so", 
+          "official": true, 
+          "percent": 78.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 34.0
+        }, 
+        {
+          "lang": "sw", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "om", 
+          "official": false, 
+          "percent": 0.42
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ZW", 
+      "languages": [
+        {
+          "lang": "sn", 
+          "official": true, 
+          "percent": 81.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 42.0
+        }, 
+        {
+          "lang": "nd", 
+          "official": true, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "mxc", 
+          "official": false, 
+          "percent": 6.5
+        }, 
+        {
+          "lang": "ndc", 
+          "official": false, 
+          "percent": 6.1
+        }, 
+        {
+          "lang": "kck", 
+          "official": false, 
+          "percent": 5.3
+        }, 
+        {
+          "lang": "ny", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "ve", 
+          "official": false, 
+          "percent": 0.64
+        }, 
+        {
+          "lang": "tn", 
+          "official": false, 
+          "percent": 0.22
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SA", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ES", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 24.0
+        }, 
+        {
+          "lang": "ca", 
+          "official": true, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "gl", 
+          "official": true, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "eu", 
+          "official": true, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "ast", 
+          "official": true, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "ext", 
+          "official": false, 
+          "percent": 0.49
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ER", 
+      "languages": [
+        {
+          "lang": "ti", 
+          "official": true, 
+          "percent": 60.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 59.0
+        }, 
+        {
+          "lang": "tig", 
+          "official": false, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 4.9
+        }, 
+        {
+          "lang": "aa", 
+          "official": false, 
+          "percent": 3.6
+        }, 
+        {
+          "lang": "ssy", 
+          "official": false, 
+          "percent": 3.6
+        }, 
+        {
+          "lang": "byn", 
+          "official": false, 
+          "percent": 1.3
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ME", 
+      "languages": [
+        {
+          "lang": "sr_Latn", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "sq", 
+          "official": false, 
+          "percent": 7.9
+        }, 
+        {
+          "lang": "sr", 
+          "official": false, 
+          "percent": 5.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MD", 
+      "languages": [
+        {
+          "lang": "ro", 
+          "official": true, 
+          "percent": 63.0
+        }, 
+        {
+          "lang": "uk", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "bg", 
+          "official": false, 
+          "percent": 9.4
+        }, 
+        {
+          "lang": "gag", 
+          "official": false, 
+          "percent": 3.3
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 3.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MG", 
+      "languages": [
+        {
+          "lang": "mg", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 69.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 18.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MF", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MA", 
+      "languages": [
+        {
+          "lang": "ary", 
+          "official": false, 
+          "percent": 87.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 62.0
+        }, 
+        {
+          "lang": "zgh", 
+          "official": false, 
+          "percent": 22.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "tzm", 
+          "official": true, 
+          "percent": 9.8
+        }, 
+        {
+          "lang": "shi", 
+          "official": false, 
+          "percent": 8.7
+        }, 
+        {
+          "lang": "shi_Latn", 
+          "official": false, 
+          "percent": 8.7
+        }, 
+        {
+          "lang": "rif", 
+          "official": false, 
+          "percent": 4.9
+        }, 
+        {
+          "lang": "rif_Latn", 
+          "official": false, 
+          "percent": 4.9
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 0.065
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MC", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 99.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "UZ", 
+      "languages": [
+        {
+          "lang": "uz", 
+          "official": true, 
+          "percent": 85.0
+        }, 
+        {
+          "lang": "uz_Cyrl", 
+          "official": true, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "kaa", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 0.76
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MM", 
+      "languages": [
+        {
+          "lang": "my", 
+          "official": true, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "shn", 
+          "official": false, 
+          "percent": 6.4
+        }, 
+        {
+          "lang": "kac", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "mnw", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "kht", 
+          "official": false, 
+          "percent": 0.0077
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ML", 
+      "languages": [
+        {
+          "lang": "bm", 
+          "official": false, 
+          "percent": 46.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 46.0
+        }, 
+        {
+          "lang": "ffm", 
+          "official": false, 
+          "percent": 7.7
+        }, 
+        {
+          "lang": "snk", 
+          "official": false, 
+          "percent": 5.9
+        }, 
+        {
+          "lang": "mwk", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "ses", 
+          "official": false, 
+          "percent": 3.4
+        }, 
+        {
+          "lang": "tmh", 
+          "official": false, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "bm_Nkoo", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "khq", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "dtm", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "kao", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.89
+        }, 
+        {
+          "lang": "bmq", 
+          "official": false, 
+          "percent": 0.86
+        }, 
+        {
+          "lang": "bze", 
+          "official": false, 
+          "percent": 0.84
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MO", 
+      "languages": [
+        {
+          "lang": "zh_Hant", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "zh", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 2.3
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MN", 
+      "languages": [
+        {
+          "lang": "mn", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "kk_Arab", 
+          "official": false, 
+          "percent": 7.2
+        }, 
+        {
+          "lang": "zh", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "ug_Cyrl", 
+          "official": false, 
+          "percent": 0.033
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MH", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "mh", 
+          "official": true, 
+          "percent": 73.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MK", 
+      "languages": [
+        {
+          "lang": "mk", 
+          "official": true, 
+          "percent": 67.0
+        }, 
+        {
+          "lang": "sq", 
+          "official": true, 
+          "percent": 25.0
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 3.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MU", 
+      "languages": [
+        {
+          "lang": "mfe", 
+          "official": false, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 72.0
+        }, 
+        {
+          "lang": "bho", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "ur", 
+          "official": false, 
+          "percent": 5.2
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "ta", 
+          "official": false, 
+          "percent": 2.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MT", 
+      "languages": [
+        {
+          "lang": "mt", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 88.0
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 56.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 11.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MW", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 63.0
+        }, 
+        {
+          "lang": "ny", 
+          "official": true, 
+          "percent": 63.0
+        }, 
+        {
+          "lang": "tum", 
+          "official": false, 
+          "percent": 8.4
+        }, 
+        {
+          "lang": "tog", 
+          "official": false, 
+          "percent": 0.98
+        }, 
+        {
+          "lang": "zu", 
+          "official": false, 
+          "percent": 0.33
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MV", 
+      "languages": [
+        {
+          "lang": "dv", 
+          "official": true, 
+          "percent": 94.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MQ", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MP", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 97.0
+        }, 
+        {
+          "lang": "ch", 
+          "official": false, 
+          "percent": 18.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MS", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 66.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MR", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 85.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "ff", 
+          "official": false, 
+          "percent": 5.7
+        }, 
+        {
+          "lang": "wo", 
+          "official": false, 
+          "percent": 0.27
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IM", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "gv", 
+          "official": true, 
+          "percent": 1.9
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "UG", 
+      "languages": [
+        {
+          "lang": "sw", 
+          "official": true, 
+          "percent": 75.0
+        }, 
+        {
+          "lang": "lg", 
           "official": false, 
           "percent": 13.0
         }, 
-        "yao": {
+        {
+          "lang": "nyn", 
+          "official": false, 
+          "percent": 6.3
+        }, 
+        {
+          "lang": "cgg", 
+          "official": false, 
+          "percent": 5.4
+        }, 
+        {
+          "lang": "xog", 
+          "official": false, 
+          "percent": 5.3
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 3.9
+        }, 
+        {
+          "lang": "teo", 
+          "official": false, 
+          "percent": 3.9
+        }, 
+        {
+          "lang": "laj", 
+          "official": false, 
+          "percent": 3.8
+        }, 
+        {
+          "lang": "ach", 
+          "official": false, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "myx", 
+          "official": false, 
+          "percent": 2.9
+        }, 
+        {
+          "lang": "rw", 
+          "official": false, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "ttj", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "hi", 
+          "official": false, 
+          "percent": 0.0056
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TZ", 
+      "languages": [
+        {
+          "lang": "sw", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 69.0
+        }, 
+        {
+          "lang": "suk", 
+          "official": false, 
+          "percent": 8.7
+        }, 
+        {
+          "lang": "nym", 
+          "official": false, 
+          "percent": 3.3
+        }, 
+        {
+          "lang": "kde", 
           "official": false, 
           "percent": 2.4
         }, 
-        "zu": {
+        {
+          "lang": "bez", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "ksb", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "mas", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "mgy", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "asa", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "lag", 
+          "official": false, 
+          "percent": 0.87
+        }, 
+        {
+          "lang": "jmc", 
+          "official": false, 
+          "percent": 0.75
+        }, 
+        {
+          "lang": "rof", 
+          "official": false, 
+          "percent": 0.75
+        }, 
+        {
+          "lang": "vun", 
+          "official": false, 
+          "percent": 0.75
+        }, 
+        {
+          "lang": "rwk", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "sbp", 
+          "official": false, 
+          "percent": 0.2
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MY", 
+      "languages": [
+        {
+          "lang": "ms", 
+          "official": true, 
+          "percent": 75.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "ta", 
+          "official": false, 
+          "percent": 4.2
+        }, 
+        {
+          "lang": "iba", 
+          "official": false, 
+          "percent": 2.5
+        }, 
+        {
+          "lang": "jv", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "zmi", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "dtp", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "bug", 
+          "official": false, 
+          "percent": 0.079
+        }, 
+        {
+          "lang": "bjn", 
+          "official": false, 
+          "percent": 0.016
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MX", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 83.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "yua", 
+          "official": false, 
+          "percent": 0.67
+        }, 
+        {
+          "lang": "nhe", 
+          "official": false, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "nhw", 
+          "official": false, 
+          "percent": 0.38
+        }, 
+        {
+          "lang": "maz", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "nch", 
+          "official": false, 
+          "percent": 0.19
+        }, 
+        {
+          "lang": "sei", 
+          "official": false, 
+          "percent": 0.0007
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IL", 
+      "languages": [
+        {
+          "lang": "he", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 85.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "ro", 
+          "official": false, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "lad", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "hu", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "am", 
+          "official": false, 
+          "percent": 0.59
+        }, 
+        {
+          "lang": "ti", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 0.096
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FR", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 39.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "oc", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "pt", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "pcd", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "gsw", 
+          "official": false, 
+          "percent": 0.91
+        }, 
+        {
+          "lang": "br", 
+          "official": false, 
+          "percent": 0.83
+        }, 
+        {
+          "lang": "co", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "ca", 
+          "official": false, 
+          "percent": 0.17
+        }, 
+        {
+          "lang": "eu", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "nl", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "frp", 
+          "official": false, 
+          "percent": 0.094
+        }, 
+        {
+          "lang": "ia", 
+          "official": false, 
+          "percent": 0.0002
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IO", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SH", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 69.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FI", 
+      "languages": [
+        {
+          "lang": "fi", 
+          "official": true, 
+          "percent": 94.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 70.0
+        }, 
+        {
+          "lang": "sv", 
+          "official": true, 
+          "percent": 44.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 0.81
+        }, 
+        {
+          "lang": "et", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "rmf", 
+          "official": false, 
+          "percent": 0.091
+        }, 
+        {
+          "lang": "se", 
+          "official": false, 
+          "percent": 0.036
+        }, 
+        {
+          "lang": "smn", 
+          "official": false, 
+          "percent": 0.011
+        }, 
+        {
+          "lang": "sms", 
+          "official": false, 
+          "percent": 0.011
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FJ", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 94.0
+        }, 
+        {
+          "lang": "hi", 
+          "official": false, 
+          "percent": 44.0
+        }, 
+        {
+          "lang": "hif", 
+          "official": true, 
+          "percent": 41.0
+        }, 
+        {
+          "lang": "fj", 
+          "official": true, 
+          "percent": 39.0
+        }, 
+        {
+          "lang": "rtm", 
+          "official": false, 
+          "percent": 0.27
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FK", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 96.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FM", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 57.0
+        }, 
+        {
+          "lang": "chk", 
+          "official": false, 
+          "percent": 30.0
+        }, 
+        {
+          "lang": "pon", 
+          "official": false, 
+          "percent": 23.0
+        }, 
+        {
+          "lang": "kos", 
+          "official": false, 
+          "percent": 7.7
+        }, 
+        {
+          "lang": "yap", 
+          "official": false, 
+          "percent": 6.3
+        }, 
+        {
+          "lang": "uli", 
+          "official": false, 
+          "percent": 2.9
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "FO", 
+      "languages": [
+        {
+          "lang": "fo", 
+          "official": true, 
+          "percent": 95.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NI", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 78.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NL", 
+      "languages": [
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 71.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 29.0
+        }, 
+        {
+          "lang": "nds", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "li", 
+          "official": false, 
+          "percent": 5.5
+        }, 
+        {
+          "lang": "fy", 
+          "official": true, 
+          "percent": 4.3
+        }, 
+        {
+          "lang": "gos", 
+          "official": false, 
+          "percent": 3.6
+        }, 
+        {
+          "lang": "id", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "zea", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "rif_Latn", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 1.2
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NO", 
+      "languages": [
+        {
+          "lang": "nb", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "nn", 
+          "official": true, 
+          "percent": 25.0
+        }, 
+        {
+          "lang": "se", 
+          "official": true, 
+          "percent": 0.29
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NA", 
+      "languages": [
+        {
+          "lang": "af", 
+          "official": false, 
+          "percent": 75.0
+        }, 
+        {
+          "lang": "kj", 
+          "official": false, 
+          "percent": 35.0
+        }, 
+        {
+          "lang": "ng", 
+          "official": false, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "naq", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "hz", 
+          "official": false, 
+          "percent": 9.1
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 0.9
+        }, 
+        {
+          "lang": "tn", 
+          "official": false, 
+          "percent": 0.56
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VU", 
+      "languages": [
+        {
+          "lang": "bi", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 83.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 50.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NC", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 96.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NE", 
+      "languages": [
+        {
+          "lang": "ha", 
+          "official": false, 
+          "percent": 41.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 29.0
+        }, 
+        {
+          "lang": "dje", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "fuq", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "tmh", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "twq", 
+          "official": false, 
+          "percent": 0.042
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NF", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 76.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 53.0
+        }, 
+        {
+          "lang": "pcm", 
+          "official": false, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "ha", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "ig", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "yo", 
+          "official": true, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "fuv", 
+          "official": false, 
+          "percent": 6.7
+        }, 
+        {
+          "lang": "tiv", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "efi", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "ibb", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "ha_Arab", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "bin", 
+          "official": false, 
+          "percent": 0.71
+        }, 
+        {
+          "lang": "kaj", 
+          "official": false, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "kcg", 
+          "official": false, 
+          "percent": 0.093
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.071
+        }, 
+        {
+          "lang": "cch", 
+          "official": false, 
+          "percent": 0.021
+        }, 
+        {
+          "lang": "amo", 
+          "official": false, 
+          "percent": 0.0087
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NZ", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "mi", 
+          "official": true, 
+          "percent": 2.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NP", 
+      "languages": [
+        {
+          "lang": "ne", 
+          "official": true, 
+          "percent": 44.0
+        }, 
+        {
+          "lang": "mai", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "bho", 
+          "official": false, 
+          "percent": 6.8
+        }, 
+        {
+          "lang": "new", 
+          "official": false, 
+          "percent": 3.3
+        }, 
+        {
+          "lang": "jml", 
+          "official": false, 
+          "percent": 3.2
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "taj", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "dty", 
+          "official": false, 
+          "percent": 2.5
+        }, 
+        {
+          "lang": "awa", 
+          "official": false, 
+          "percent": 2.2
+        }, 
+        {
+          "lang": "thl", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "bap", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "tdg", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "thr", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "lif", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "mgp", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "thq", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "mrd", 
+          "official": false, 
+          "percent": 0.83
+        }, 
+        {
+          "lang": "bfy", 
+          "official": false, 
+          "percent": 0.54
+        }, 
+        {
+          "lang": "xsr", 
+          "official": false, 
+          "percent": 0.52
+        }, 
+        {
+          "lang": "rjs", 
+          "official": false, 
+          "percent": 0.44
+        }, 
+        {
+          "lang": "tsf", 
+          "official": false, 
+          "percent": 0.43
+        }, 
+        {
+          "lang": "ggn", 
+          "official": false, 
+          "percent": 0.42
+        }, 
+        {
+          "lang": "hi", 
+          "official": false, 
+          "percent": 0.42
+        }, 
+        {
+          "lang": "gvr", 
+          "official": false, 
+          "percent": 0.29
+        }, 
+        {
+          "lang": "bo", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "tkt", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "tdh", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "bn", 
+          "official": false, 
+          "percent": 0.094
+        }, 
+        {
+          "lang": "unr_Deva", 
+          "official": false, 
+          "percent": 0.019
+        }, 
+        {
+          "lang": "lep", 
+          "official": false, 
+          "percent": 0.0096
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NR", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 97.0
+        }, 
+        {
+          "lang": "na", 
+          "official": true, 
+          "percent": 71.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "NU", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 69.0
+        }, 
+        {
+          "lang": "niu", 
+          "official": true, 
+          "percent": 69.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CK", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 95.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "XK", 
+      "languages": [
+        {
+          "lang": "sq", 
+          "official": true, 
+          "percent": 92.0
+        }, 
+        {
+          "lang": "aln", 
+          "official": false, 
+          "percent": 74.0
+        }, 
+        {
+          "lang": "sr", 
+          "official": true, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "sr_Latn", 
+          "official": true, 
+          "percent": 5.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CI", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 49.0
+        }, 
+        {
+          "lang": "bci", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "sef", 
+          "official": false, 
+          "percent": 4.3
+        }, 
+        {
+          "lang": "dnj", 
+          "official": false, 
+          "percent": 4.0
+        }, 
+        {
+          "lang": "kfo", 
+          "official": false, 
+          "percent": 0.23
+        }, 
+        {
+          "lang": "bqv", 
+          "official": false, 
+          "percent": 0.17
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CH", 
+      "languages": [
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 73.0
+        }, 
+        {
+          "lang": "gsw", 
+          "official": true, 
+          "percent": 65.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "it", 
+          "official": true, 
+          "percent": 4.3
+        }, 
+        {
+          "lang": "lmo", 
+          "official": false, 
+          "percent": 4.1
+        }, 
+        {
+          "lang": "pt", 
+          "official": false, 
+          "percent": 3.4
+        }, 
+        {
+          "lang": "rm", 
+          "official": true, 
+          "percent": 0.5
+        }, 
+        {
+          "lang": "rmo", 
+          "official": false, 
+          "percent": 0.29
+        }, 
+        {
+          "lang": "wae", 
+          "official": false, 
+          "percent": 0.12
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CO", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "guc", 
+          "official": false, 
+          "percent": 0.27
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CN", 
+      "languages": [
+        {
+          "lang": "zh", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "wuu", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "yue_Hans", 
+          "official": false, 
+          "percent": 5.2
+        }, 
+        {
+          "lang": "hsn", 
+          "official": false, 
+          "percent": 2.9
+        }, 
+        {
+          "lang": "hak", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "nan", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "gan", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "ii", 
+          "official": false, 
+          "percent": 0.6
+        }, 
+        {
+          "lang": "ug", 
+          "official": true, 
+          "percent": 0.55
+        }, 
+        {
+          "lang": "za", 
+          "official": true, 
+          "percent": 0.31
+        }, 
+        {
+          "lang": "mn_Mong", 
+          "official": true, 
+          "percent": 0.26
+        }, 
+        {
+          "lang": "bo", 
+          "official": true, 
+          "percent": 0.2
+        }, 
+        {
+          "lang": "ko", 
+          "official": true, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "kk_Arab", 
+          "official": false, 
+          "percent": 0.086
+        }, 
+        {
+          "lang": "lis", 
+          "official": false, 
+          "percent": 0.045
+        }, 
+        {
+          "lang": "ky_Arab", 
+          "official": false, 
+          "percent": 0.034
+        }, 
+        {
+          "lang": "nxq", 
+          "official": false, 
+          "percent": 0.024
+        }, 
+        {
+          "lang": "khb", 
+          "official": false, 
+          "percent": 0.019
+        }, 
+        {
+          "lang": "tdd", 
+          "official": false, 
+          "percent": 0.019
+        }, 
+        {
+          "lang": "lcp", 
+          "official": false, 
+          "percent": 0.0058
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 0.0045
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 0.001
+        }, 
+        {
+          "lang": "vi", 
+          "official": false, 
+          "percent": 0.0005
+        }, 
+        {
+          "lang": "uz_Cyrl", 
+          "official": false, 
+          "percent": 0.0004
+        }, 
+        {
+          "lang": "lzh", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CM", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 68.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 38.0
+        }, 
+        {
+          "lang": "bum", 
+          "official": false, 
+          "percent": 4.6
+        }, 
+        {
+          "lang": "ff", 
+          "official": false, 
+          "percent": 3.6
+        }, 
+        {
+          "lang": "ewo", 
+          "official": false, 
+          "percent": 3.1
+        }, 
+        {
+          "lang": "ybb", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "bbj", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "nnh", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "bkm", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "bas", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "bax", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "byv", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "mua", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "maf", 
+          "official": false, 
+          "percent": 0.73
+        }, 
+        {
+          "lang": "bfd", 
+          "official": false, 
+          "percent": 0.57
+        }, 
+        {
+          "lang": "bss", 
+          "official": false, 
+          "percent": 0.54
+        }, 
+        {
+          "lang": "kkj", 
+          "official": false, 
+          "percent": 0.54
+        }, 
+        {
+          "lang": "dua", 
+          "official": false, 
+          "percent": 0.48
+        }, 
+        {
+          "lang": "mgo", 
+          "official": false, 
+          "percent": 0.47
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "jgo", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "ksf", 
+          "official": false, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "agq", 
+          "official": false, 
+          "percent": 0.14
+        }, 
+        {
+          "lang": "ha_Arab", 
+          "official": false, 
+          "percent": 0.14
+        }, 
+        {
+          "lang": "nmg", 
+          "official": false, 
+          "percent": 0.036
+        }, 
+        {
+          "lang": "yav", 
+          "official": false, 
+          "percent": 0.0092
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CL", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 9.5
+        }, 
+        {
+          "lang": "arn", 
+          "official": false, 
+          "percent": 1.5
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CC", 
+      "languages": [
+        {
+          "lang": "ms_Arab", 
+          "official": false, 
+          "percent": 83.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 17.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CA", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 22.0
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "pdt", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "cr", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "crk", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 0.045
+        }, 
+        {
+          "lang": "iu", 
+          "official": true, 
+          "percent": 0.042
+        }, 
+        {
+          "lang": "iu_Latn", 
+          "official": true, 
+          "percent": 0.042
+        }, 
+        {
+          "lang": "moe", 
+          "official": false, 
+          "percent": 0.033
+        }, 
+        {
+          "lang": "crj", 
+          "official": false, 
+          "percent": 0.021
+        }, 
+        {
+          "lang": "atj", 
+          "official": false, 
+          "percent": 0.016
+        }, 
+        {
+          "lang": "crl", 
+          "official": false, 
+          "percent": 0.015
+        }, 
+        {
+          "lang": "csw", 
+          "official": false, 
+          "percent": 0.014
+        }, 
+        {
+          "lang": "crm", 
+          "official": false, 
+          "percent": 0.013
+        }, 
+        {
+          "lang": "ikt", 
+          "official": true, 
+          "percent": 0.011
+        }, 
+        {
+          "lang": "moh", 
+          "official": false, 
+          "percent": 0.0098
+        }, 
+        {
+          "lang": "dgr", 
+          "official": false, 
+          "percent": 0.0074
+        }, 
+        {
+          "lang": "den", 
+          "official": false, 
+          "percent": 0.0065
+        }, 
+        {
+          "lang": "scs", 
+          "official": false, 
+          "percent": 0.0035
+        }, 
+        {
+          "lang": "nsk", 
+          "official": false, 
+          "percent": 0.0033
+        }, 
+        {
+          "lang": "chp", 
+          "official": false, 
+          "percent": 0.0022
+        }, 
+        {
+          "lang": "gwi", 
+          "official": false, 
+          "percent": 0.0016
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CG", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 84.0
+        }, 
+        {
+          "lang": "ln", 
+          "official": false, 
+          "percent": 2.4
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CF", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 49.0
+        }, 
+        {
+          "lang": "sg", 
+          "official": true, 
+          "percent": 49.0
+        }, 
+        {
+          "lang": "ln", 
+          "official": false, 
+          "percent": 0.24
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CD", 
+      "languages": [
+        {
+          "lang": "sw", 
+          "official": true, 
+          "percent": 50.0
+        }, 
+        {
+          "lang": "lua", 
+          "official": true, 
+          "percent": 9.6
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 3.8
+        }, 
+        {
+          "lang": "ln", 
+          "official": true, 
+          "percent": 3.1
+        }, 
+        {
+          "lang": "lu", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "kg", 
+          "official": true, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "lol", 
+          "official": false, 
+          "percent": 0.61
+        }, 
+        {
+          "lang": "rw", 
+          "official": false, 
+          "percent": 0.38
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CZ", 
+      "languages": [
+        {
+          "lang": "cs", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "sk", 
+          "official": false, 
+          "percent": 16.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 0.49
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CY", 
+      "languages": [
+        {
+          "lang": "el", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 73.0
+        }, 
+        {
+          "lang": "tr", 
+          "official": true, 
+          "percent": 23.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.11
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CX", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 63.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CR", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 95.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CP", 
+      "languages": [
+        {
+          "lang": "und", 
+          "official": false, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CW", 
+      "languages": [
+        {
+          "lang": "pap", 
+          "official": true, 
+          "percent": 81.0
+        }, 
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 8.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 3.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CV", 
+      "languages": [
+        {
+          "lang": "kea", 
+          "official": false, 
+          "percent": 91.0
+        }, 
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 76.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "CU", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SZ", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "ss", 
+          "official": true, 
+          "percent": 58.0
+        }, 
+        {
+          "lang": "zu", 
+          "official": false, 
+          "percent": 6.8
+        }, 
+        {
+          "lang": "ts", 
+          "official": false, 
+          "percent": 1.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SY", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 8.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 5.9
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "syr", 
+          "official": false, 
+          "percent": 0.084
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SX", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 68.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "vic", 
+          "official": false, 
+          "percent": 7.4
+        }, 
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 3.8
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KG", 
+      "languages": [
+        {
+          "lang": "ky", 
+          "official": true, 
+          "percent": 48.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": true, 
+          "percent": 36.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KE", 
+      "languages": [
+        {
+          "lang": "sw", 
+          "official": true, 
+          "percent": 66.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 19.0
+        }, 
+        {
+          "lang": "ki", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "luy", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "luo", 
+          "official": false, 
+          "percent": 9.8
+        }, 
+        {
+          "lang": "kam", 
+          "official": false, 
+          "percent": 7.6
+        }, 
+        {
+          "lang": "kln", 
+          "official": false, 
+          "percent": 7.6
+        }, 
+        {
+          "lang": "guz", 
+          "official": false, 
+          "percent": 4.9
+        }, 
+        {
+          "lang": "mer", 
+          "official": false, 
+          "percent": 4.0
+        }, 
+        {
+          "lang": "mas", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "ebu", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "so", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "dav", 
+          "official": false, 
+          "percent": 0.82
+        }, 
+        {
+          "lang": "teo", 
+          "official": false, 
+          "percent": 0.74
+        }, 
+        {
+          "lang": "pko", 
+          "official": false, 
+          "percent": 0.7
+        }, 
+        {
+          "lang": "om", 
+          "official": false, 
+          "percent": 0.47
+        }, 
+        {
+          "lang": "saq", 
+          "official": false, 
+          "percent": 0.46
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.046
+        }, 
+        {
+          "lang": "pa", 
+          "official": false, 
+          "percent": 0.021
+        }, 
+        {
+          "lang": "gu", 
+          "official": false, 
+          "percent": 0.011
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SS", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "nus", 
+          "official": false, 
+          "percent": 5.6
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SR", 
+      "languages": [
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "srn", 
+          "official": false, 
+          "percent": 68.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 1.2
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KI", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "gil", 
+          "official": true, 
+          "percent": 60.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KH", 
+      "languages": [
+        {
+          "lang": "km", 
+          "official": true, 
+          "percent": 89.0
+        }, 
+        {
+          "lang": "cja", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "kdt", 
+          "official": false, 
+          "percent": 0.11
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KN", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KM", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 66.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 56.0
+        }, 
+        {
+          "lang": "zdj", 
+          "official": true, 
+          "percent": 37.0
+        }, 
+        {
+          "lang": "wni", 
+          "official": true, 
+          "percent": 34.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ST", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 85.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SK", 
+      "languages": [
+        {
+          "lang": "sk", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "cs", 
+          "official": false, 
+          "percent": 47.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 26.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 22.0
+        }, 
+        {
+          "lang": "hu", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "uk", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 0.93
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KR", 
+      "languages": [
+        {
+          "lang": "ko", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SI", 
+      "languages": [
+        {
+          "lang": "sl", 
+          "official": true, 
+          "percent": 87.0
+        }, 
+        {
+          "lang": "hr", 
+          "official": false, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 59.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 42.0
+        }, 
+        {
+          "lang": "hu", 
+          "official": false, 
+          "percent": 0.47
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 0.2
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KP", 
+      "languages": [
+        {
+          "lang": "ko", 
+          "official": true, 
+          "percent": 88.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KW", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SN", 
+      "languages": [
+        {
+          "lang": "wo", 
+          "official": true, 
+          "percent": 70.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 39.0
+        }, 
+        {
+          "lang": "ff", 
+          "official": true, 
+          "percent": 21.0
+        }, 
+        {
+          "lang": "srr", 
+          "official": true, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "dyo", 
+          "official": true, 
+          "percent": 2.6
+        }, 
+        {
+          "lang": "sav", 
+          "official": true, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "mfv", 
+          "official": true, 
+          "percent": 0.77
+        }, 
+        {
+          "lang": "bjt", 
+          "official": true, 
+          "percent": 0.61
+        }, 
+        {
+          "lang": "snf", 
+          "official": true, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "knf", 
+          "official": true, 
+          "percent": 0.21
+        }, 
+        {
+          "lang": "bsc", 
+          "official": true, 
+          "percent": 0.098
+        }, 
+        {
+          "lang": "mey", 
+          "official": true, 
+          "percent": 0.049
+        }, 
+        {
+          "lang": "tnr", 
+          "official": true, 
+          "percent": 0.023
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SM", 
+      "languages": [
+        {
+          "lang": "it", 
+          "official": true, 
+          "percent": 89.0
+        }, 
+        {
+          "lang": "eo", 
+          "official": false, 
+          "percent": 0.89
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SL", 
+      "languages": [
+        {
+          "lang": "kri", 
+          "official": false, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 35.0
+        }, 
+        {
+          "lang": "men", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "tem", 
+          "official": false, 
+          "percent": 26.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SC", 
+      "languages": [
+        {
+          "lang": "crs", 
+          "official": false, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 60.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 38.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KZ", 
+      "languages": [
+        {
+          "lang": "ru", 
+          "official": true, 
+          "percent": 72.0
+        }, 
+        {
+          "lang": "kk", 
+          "official": true, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 6.4
+        }, 
+        {
+          "lang": "ug_Cyrl", 
+          "official": false, 
+          "percent": 2.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "KY", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "zh", 
+          "official": true, 
+          "percent": 77.0
+        }, 
+        {
+          "lang": "ms", 
+          "official": true, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "ta", 
+          "official": true, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 0.17
+        }, 
+        {
+          "lang": "pa", 
+          "official": false, 
+          "percent": 0.16
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SE", 
+      "languages": [
+        {
+          "lang": "sv", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "fi", 
+          "official": true, 
+          "percent": 2.2
+        }, 
+        {
+          "lang": "fit", 
+          "official": false, 
+          "percent": 0.55
+        }, 
+        {
+          "lang": "se", 
+          "official": false, 
+          "percent": 0.33
+        }, 
+        {
+          "lang": "rmu", 
+          "official": false, 
+          "percent": 0.095
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 0.03
+        }, 
+        {
+          "lang": "smj", 
+          "official": false, 
+          "percent": 0.015
+        }, 
+        {
+          "lang": "sma", 
+          "official": false, 
+          "percent": 0.003
+        }, 
+        {
+          "lang": "ia", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "SD", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "bej", 
+          "official": false, 
+          "percent": 5.4
+        }, 
+        {
+          "lang": "fvr", 
+          "official": false, 
+          "percent": 2.7
+        }, 
+        {
+          "lang": "ha_Arab", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "mls", 
+          "official": false, 
+          "percent": 0.99
+        }, 
+        {
+          "lang": "fia", 
+          "official": false, 
+          "percent": 0.83
+        }, 
+        {
+          "lang": "zag", 
+          "official": false, 
+          "percent": 0.51
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DO", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 78.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 0.075
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DM", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 94.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DJ", 
+      "languages": [
+        {
+          "lang": "aa", 
+          "official": false, 
+          "percent": 42.0
+        }, 
+        {
+          "lang": "so", 
+          "official": false, 
+          "percent": 41.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 7.3
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 2.1
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DK", 
+      "languages": [
+        {
+          "lang": "da", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 47.0
+        }, 
+        {
+          "lang": "sv", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "fo", 
+          "official": false, 
+          "percent": 0.38
+        }, 
+        {
+          "lang": "kl", 
+          "official": true, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "jut", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 99.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DE", 
+      "languages": [
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 91.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 18.0
+        }, 
+        {
+          "lang": "bar", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "nds", 
+          "official": false, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "nl", 
+          "official": false, 
+          "percent": 9.0
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "vmf", 
+          "official": false, 
+          "percent": 6.0
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 2.5
+        }, 
+        {
+          "lang": "gsw", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "da", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "swg", 
+          "official": false, 
+          "percent": 1.0
+        }, 
+        {
+          "lang": "hr", 
+          "official": false, 
+          "percent": 0.79
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 0.66
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.38
+        }, 
+        {
+          "lang": "ksh", 
+          "official": false, 
+          "percent": 0.3
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 0.29
+        }, 
+        {
+          "lang": "hsb", 
+          "official": false, 
+          "percent": 0.016
+        }, 
+        {
+          "lang": "frr", 
+          "official": false, 
+          "percent": 0.012
+        }, 
+        {
+          "lang": "dsb", 
+          "official": false, 
+          "percent": 0.0087
+        }, 
+        {
+          "lang": "frs", 
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        {
+          "lang": "stq", 
+          "official": false, 
+          "percent": 0.0012
+        }, 
+        {
+          "lang": "pfl", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "YE", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 74.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 9.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "DZ", 
+      "languages": [
+        {
+          "lang": "arq", 
+          "official": false, 
+          "percent": 83.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 74.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 20.0
+        }, 
+        {
+          "lang": "kab", 
+          "official": false, 
+          "percent": 7.8
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 7.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "US", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 96.0
+        }, 
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 9.6
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 0.69
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 0.47
+        }, 
+        {
+          "lang": "fil", 
+          "official": false, 
+          "percent": 0.42
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "vi", 
+          "official": false, 
+          "percent": 0.34
+        }, 
+        {
+          "lang": "ko", 
+          "official": false, 
+          "percent": 0.3
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "nv", 
+          "official": false, 
+          "percent": 0.05
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 0.049
+        }, 
+        {
+          "lang": "pdc", 
+          "official": false, 
+          "percent": 0.039
+        }, 
+        {
+          "lang": "haw", 
+          "official": true, 
+          "percent": 0.0089
+        }, 
+        {
+          "lang": "frc", 
+          "official": false, 
+          "percent": 0.0084
+        }, 
+        {
+          "lang": "chr", 
+          "official": false, 
+          "percent": 0.0077
+        }, 
+        {
+          "lang": "esu", 
+          "official": false, 
+          "percent": 0.0062
+        }, 
+        {
+          "lang": "dak", 
+          "official": false, 
+          "percent": 0.0059
+        }, 
+        {
+          "lang": "cho", 
+          "official": false, 
+          "percent": 0.0033
+        }, 
+        {
+          "lang": "lkt", 
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        {
+          "lang": "ik", 
+          "official": false, 
+          "percent": 0.0024
+        }, 
+        {
+          "lang": "mus", 
+          "official": false, 
+          "percent": 0.0012
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "UY", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 88.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "YT", 
+      "languages": [
+        {
+          "lang": "swb", 
+          "official": false, 
+          "percent": 88.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 57.0
+        }, 
+        {
+          "lang": "buc", 
+          "official": false, 
+          "percent": 23.0
+        }, 
+        {
+          "lang": "sw", 
+          "official": false, 
+          "percent": 1.4
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "UM", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LB", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 40.0
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 5.2
+        }, 
+        {
+          "lang": "ku_Arab", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 0.37
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LC", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 90.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LA", 
+      "languages": [
+        {
+          "lang": "lo", 
+          "official": true, 
+          "percent": 69.0
+        }, 
+        {
+          "lang": "kjg", 
+          "official": false, 
+          "percent": 5.8
+        }, 
+        {
+          "lang": "kdt", 
+          "official": false, 
+          "percent": 0.96
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TV", 
+      "languages": [
+        {
+          "lang": "tvl", 
+          "official": true, 
+          "percent": 90.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 9.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TW", 
+      "languages": [
+        {
+          "lang": "zh_Hant", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "trv", 
+          "official": false, 
+          "percent": 0.02
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TT", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 88.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 0.34
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TR", 
+      "languages": [
+        {
+          "lang": "tr", 
+          "official": true, 
+          "percent": 93.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 5.5
+        }, 
+        {
+          "lang": "zza", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "kbd", 
+          "official": false, 
+          "percent": 0.77
+        }, 
+        {
+          "lang": "az", 
+          "official": false, 
+          "percent": 0.74
+        }, 
+        {
+          "lang": "az_Arab", 
+          "official": false, 
+          "percent": 0.65
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "bgx", 
+          "official": false, 
+          "percent": 0.46
+        }, 
+        {
+          "lang": "bg", 
+          "official": false, 
+          "percent": 0.42
+        }, 
+        {
+          "lang": "ady", 
+          "official": false, 
+          "percent": 0.39
+        }, 
+        {
+          "lang": "kiu", 
+          "official": false, 
+          "percent": 0.19
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 0.056
+        }, 
+        {
+          "lang": "ka", 
+          "official": false, 
+          "percent": 0.056
+        }, 
+        {
+          "lang": "lzz", 
+          "official": false, 
+          "percent": 0.028
+        }, 
+        {
+          "lang": "sr_Latn", 
+          "official": false, 
+          "percent": 0.028
+        }, 
+        {
+          "lang": "sq", 
+          "official": false, 
+          "percent": 0.021
+        }, 
+        {
+          "lang": "ab", 
+          "official": false, 
+          "percent": 0.0049
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.0049
+        }, 
+        {
+          "lang": "tru", 
+          "official": false, 
+          "percent": 0.0037
+        }, 
+        {
+          "lang": "uz", 
+          "official": false, 
+          "percent": 0.0024
+        }, 
+        {
+          "lang": "ky_Latn", 
+          "official": false, 
+          "percent": 0.0014
+        }, 
+        {
+          "lang": "kk", 
+          "official": false, 
+          "percent": 0.0007
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LK", 
+      "languages": [
+        {
+          "lang": "si", 
+          "official": true, 
+          "percent": 68.0
+        }, 
+        {
+          "lang": "ta", 
+          "official": true, 
+          "percent": 15.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 10.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LI", 
+      "languages": [
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "gsw", 
+          "official": true, 
+          "percent": 85.0
+        }, 
+        {
+          "lang": "wae", 
+          "official": false, 
+          "percent": 3.4
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LV", 
+      "languages": [
+        {
+          "lang": "lv", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 46.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 38.0
+        }, 
+        {
+          "lang": "ltg", 
+          "official": false, 
+          "percent": 8.9
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TO", 
+      "languages": [
+        {
+          "lang": "to", 
+          "official": true, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 28.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LT", 
+      "languages": [
+        {
+          "lang": "lt", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": false, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 38.0
+        }, 
+        {
+          "lang": "de", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "sgs", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LU", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 87.0
+        }, 
+        {
+          "lang": "lb", 
+          "official": true, 
+          "percent": 67.0
+        }, 
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 63.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 56.0
+        }, 
+        {
+          "lang": "pt", 
+          "official": false, 
+          "percent": 16.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LR", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 83.0
+        }, 
+        {
+          "lang": "kpe", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "vai", 
+          "official": false, 
+          "percent": 2.6
+        }, 
+        {
+          "lang": "men", 
+          "official": false, 
+          "percent": 0.48
+        }, 
+        {
+          "lang": "vai_Latn", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LS", 
+      "languages": [
+        {
+          "lang": "st", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "zu", 
+          "official": false, 
+          "percent": 14.0
+        }, 
+        {
+          "lang": "ss", 
+          "official": false, 
+          "percent": 2.4
+        }, 
+        {
+          "lang": "xh", 
+          "official": false, 
+          "percent": 0.99
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TH", 
+      "languages": [
+        {
+          "lang": "th", 
+          "official": true, 
+          "percent": 80.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "tts", 
+          "official": false, 
+          "percent": 24.0
+        }, 
+        {
+          "lang": "nod", 
+          "official": false, 
+          "percent": 9.6
+        }, 
+        {
+          "lang": "sou", 
+          "official": false, 
+          "percent": 8.0
+        }, 
+        {
+          "lang": "mfa", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "kxm", 
+          "official": false, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "kdt", 
+          "official": false, 
+          "percent": 0.48
+        }, 
+        {
+          "lang": "mnw", 
+          "official": false, 
+          "percent": 0.17
+        }, 
+        {
+          "lang": "shn", 
+          "official": false, 
+          "percent": 0.096
+        }, 
+        {
+          "lang": "lcp", 
+          "official": false, 
+          "percent": 0.01
+        }, 
+        {
+          "lang": "lwl", 
+          "official": false, 
+          "percent": 0.01
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TF", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TG", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "ee", 
+          "official": false, 
+          "percent": 17.0
+        }, 
+        {
+          "lang": "ife", 
+          "official": false, 
+          "percent": 1.3
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TD", 
+      "languages": [
+        {
+          "lang": "fr", 
+          "official": true, 
+          "percent": 26.0
+        }, 
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 17.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "TC", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "LY", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 74.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VA", 
+      "languages": [
+        {
+          "lang": "it", 
+          "official": true, 
+          "percent": 82.0
+        }, 
+        {
+          "lang": "la", 
+          "official": false, 
+          "percent": 82.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AC", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 99.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VC", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 96.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AE", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 78.0
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "ps", 
+          "official": false, 
+          "percent": 2.9
+        }, 
+        {
+          "lang": "bal", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 1.9
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AD", 
+      "languages": [
+        {
+          "lang": "ca", 
+          "official": true, 
+          "percent": 51.0
+        }, 
+        {
+          "lang": "es", 
+          "official": false, 
+          "percent": 43.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 6.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AG", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 86.0
+        }, 
+        {
+          "lang": "pt", 
+          "official": false, 
+          "percent": 1.7
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AF", 
+      "languages": [
+        {
+          "lang": "fa", 
+          "official": true, 
+          "percent": 50.0
+        }, 
+        {
+          "lang": "ps", 
+          "official": true, 
+          "percent": 43.0
+        }, 
+        {
+          "lang": "haz", 
+          "official": false, 
+          "percent": 5.9
+        }, 
+        {
+          "lang": "uz_Arab", 
+          "official": true, 
+          "percent": 4.7
+        }, 
+        {
+          "lang": "tk", 
+          "official": true, 
+          "percent": 1.7
+        }, 
+        {
+          "lang": "prd", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "bal", 
+          "official": true, 
+          "percent": 0.67
+        }, 
+        {
+          "lang": "bgn", 
+          "official": false, 
+          "percent": 0.63
+        }, 
+        {
+          "lang": "ug", 
+          "official": false, 
+          "percent": 0.0088
+        }, 
+        {
+          "lang": "kk_Arab", 
+          "official": false, 
+          "percent": 0.0059
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AI", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 95.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "VI", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 75.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IS", 
+      "languages": [
+        {
+          "lang": "is", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "da", 
+          "official": false, 
+          "percent": 0.66
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IR", 
+      "languages": [
+        {
+          "lang": "fa", 
+          "official": true, 
+          "percent": 75.0
+        }, 
+        {
+          "lang": "az_Arab", 
+          "official": false, 
+          "percent": 24.0
+        }, 
+        {
+          "lang": "mzn", 
+          "official": false, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "glk", 
+          "official": false, 
+          "percent": 4.6
+        }, 
+        {
+          "lang": "ckb", 
+          "official": false, 
+          "percent": 3.9
+        }, 
+        {
+          "lang": "sdh", 
+          "official": false, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "tk", 
+          "official": false, 
+          "percent": 2.8
+        }, 
+        {
+          "lang": "lrc", 
+          "official": false, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "ar", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "bal", 
+          "official": false, 
+          "percent": 2.0
+        }, 
+        {
+          "lang": "rmt", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "bqi", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "luz", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "lki", 
+          "official": false, 
+          "percent": 0.76
+        }, 
+        {
+          "lang": "bgn", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "prd", 
+          "official": false, 
+          "percent": 0.5
+        }, 
+        {
+          "lang": "hy", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "ps", 
+          "official": false, 
+          "percent": 0.16
+        }, 
+        {
+          "lang": "ka", 
+          "official": false, 
+          "percent": 0.071
+        }, 
+        {
+          "lang": "gbz", 
+          "official": false, 
+          "percent": 0.0098
+        }, 
+        {
+          "lang": "kk_Arab", 
+          "official": false, 
+          "percent": 0.0037
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AM", 
+      "languages": [
+        {
+          "lang": "hy", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 3.3
+        }, 
+        {
+          "lang": "az", 
+          "official": false, 
+          "percent": 0.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AL", 
+      "languages": [
+        {
+          "lang": "sq", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "mk", 
+          "official": false, 
+          "percent": 0.47
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AO", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 67.0
+        }, 
+        {
+          "lang": "umb", 
+          "official": false, 
+          "percent": 29.0
+        }, 
+        {
+          "lang": "kmb", 
+          "official": false, 
+          "percent": 25.0
+        }, 
+        {
+          "lang": "ln", 
+          "official": false, 
+          "percent": 0.67
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AQ", 
+      "languages": [
+        {
+          "lang": "und", 
+          "official": false, 
+          "percent": 100.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AS", 
+      "languages": [
+        {
+          "lang": "sm", 
+          "official": true, 
+          "percent": 99.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 97.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AR", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 100.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "cy", 
+          "official": false, 
+          "percent": 0.066
+        }, 
+        {
+          "lang": "gn", 
+          "official": false, 
+          "percent": 0.047
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AU", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 96.0
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "wbp", 
+          "official": false, 
+          "percent": 0.011
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AT", 
+      "languages": [
+        {
+          "lang": "de", 
+          "official": true, 
+          "percent": 97.0
+        }, 
+        {
+          "lang": "bar", 
+          "official": false, 
+          "percent": 95.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 73.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "it", 
+          "official": false, 
+          "percent": 9.0
+        }, 
+        {
+          "lang": "hr", 
+          "official": true, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "sl", 
+          "official": true, 
+          "percent": 0.37
+        }, 
+        {
+          "lang": "hu", 
+          "official": true, 
+          "percent": 0.27
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AW", 
+      "languages": [
+        {
+          "lang": "nl", 
+          "official": true, 
+          "percent": 97.0
+        }, 
+        {
+          "lang": "pap", 
+          "official": true, 
+          "percent": 61.0
+        }, 
+        {
+          "lang": "en", 
+          "official": false, 
+          "percent": 2.6
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IN", 
+      "languages": [
+        {
+          "lang": "hi", 
+          "official": true, 
+          "percent": 41.0
+        }, 
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 19.0
+        }, 
+        {
+          "lang": "bn", 
+          "official": true, 
+          "percent": 8.1
+        }, 
+        {
+          "lang": "te", 
+          "official": true, 
+          "percent": 7.2
+        }, 
+        {
+          "lang": "mr", 
+          "official": true, 
+          "percent": 7.0
+        }, 
+        {
+          "lang": "ta", 
+          "official": true, 
+          "percent": 5.9
+        }, 
+        {
+          "lang": "ur", 
+          "official": true, 
+          "percent": 5.0
+        }, 
+        {
+          "lang": "gu", 
+          "official": true, 
+          "percent": 4.5
+        }, 
+        {
+          "lang": "kn", 
+          "official": true, 
+          "percent": 3.7
+        }, 
+        {
+          "lang": "ml", 
+          "official": true, 
+          "percent": 3.2
+        }, 
+        {
+          "lang": "or", 
+          "official": true, 
+          "percent": 3.2
+        }, 
+        {
+          "lang": "pa", 
+          "official": true, 
+          "percent": 2.8
+        }, 
+        {
+          "lang": "bho", 
+          "official": false, 
+          "percent": 2.3
+        }, 
+        {
+          "lang": "awa", 
+          "official": false, 
+          "percent": 1.9
+        }, 
+        {
+          "lang": "as", 
+          "official": true, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "bgc", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "mag", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "mai", 
+          "official": true, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "mwr", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "hne", 
+          "official": false, 
+          "percent": 1.1
+        }, 
+        {
+          "lang": "dcc", 
+          "official": false, 
+          "percent": 0.99
+        }, 
+        {
+          "lang": "bjj", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "ne", 
+          "official": true, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "sat", 
+          "official": true, 
+          "percent": 0.55
+        }, 
+        {
+          "lang": "wtm", 
+          "official": false, 
+          "percent": 0.46
+        }, 
+        {
+          "lang": "rkt", 
+          "official": false, 
+          "percent": 0.44
+        }, 
+        {
+          "lang": "ks", 
+          "official": true, 
+          "percent": 0.41
+        }, 
+        {
+          "lang": "kok", 
+          "official": true, 
+          "percent": 0.37
+        }, 
+        {
+          "lang": "gom", 
+          "official": false, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "swv", 
+          "official": false, 
+          "percent": 0.28
+        }, 
+        {
+          "lang": "gbm", 
+          "official": false, 
+          "percent": 0.27
+        }, 
+        {
+          "lang": "lmn", 
+          "official": false, 
+          "percent": 0.27
+        }, 
+        {
+          "lang": "sd", 
+          "official": true, 
+          "percent": 0.26
+        }, 
+        {
+          "lang": "gon", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "kfy", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "doi", 
+          "official": false, 
+          "percent": 0.19
+        }, 
+        {
+          "lang": "kru", 
+          "official": false, 
+          "percent": 0.19
+        }, 
+        {
+          "lang": "sck", 
+          "official": false, 
+          "percent": 0.18
+        }, 
+        {
+          "lang": "wbq", 
+          "official": false, 
+          "percent": 0.18
+        }, 
+        {
+          "lang": "xnr", 
+          "official": false, 
+          "percent": 0.16
+        }, 
+        {
+          "lang": "khn", 
+          "official": false, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "tcy", 
+          "official": false, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "wbr", 
+          "official": false, 
+          "percent": 0.15
+        }, 
+        {
+          "lang": "brx", 
+          "official": false, 
+          "percent": 0.14
+        }, 
+        {
+          "lang": "noe", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "bhb", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "mni", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "raj", 
+          "official": false, 
+          "percent": 0.1
+        }, 
+        {
+          "lang": "hoc", 
+          "official": false, 
+          "percent": 0.099
+        }, 
+        {
+          "lang": "mtr", 
+          "official": false, 
+          "percent": 0.098
+        }, 
+        {
+          "lang": "unr", 
+          "official": false, 
+          "percent": 0.095
+        }, 
+        {
+          "lang": "bhi", 
+          "official": false, 
+          "percent": 0.092
+        }, 
+        {
+          "lang": "hoj", 
+          "official": false, 
+          "percent": 0.082
+        }, 
+        {
+          "lang": "kha", 
+          "official": true, 
+          "percent": 0.08
+        }, 
+        {
+          "lang": "kfr", 
+          "official": false, 
+          "percent": 0.075
+        }, 
+        {
+          "lang": "grt", 
+          "official": false, 
+          "percent": 0.053
+        }, 
+        {
+          "lang": "unx", 
+          "official": false, 
+          "percent": 0.048
+        }, 
+        {
+          "lang": "bfy", 
+          "official": false, 
+          "percent": 0.037
+        }, 
+        {
+          "lang": "srx", 
+          "official": false, 
+          "percent": 0.035
+        }, 
+        {
+          "lang": "saz", 
+          "official": false, 
+          "percent": 0.029
+        }, 
+        {
+          "lang": "ccp", 
+          "official": false, 
+          "percent": 0.028
+        }, 
+        {
+          "lang": "sd_Deva", 
+          "official": true, 
+          "percent": 0.026
+        }, 
+        {
+          "lang": "bfq", 
+          "official": false, 
+          "percent": 0.023
+        }, 
+        {
+          "lang": "njo", 
+          "official": false, 
+          "percent": 0.023
+        }, 
+        {
+          "lang": "ria", 
+          "official": false, 
+          "percent": 0.013
+        }, 
+        {
+          "lang": "bo", 
+          "official": false, 
+          "percent": 0.011
+        }, 
+        {
+          "lang": "bpy", 
+          "official": false, 
+          "percent": 0.0068
+        }, 
+        {
+          "lang": "bft", 
+          "official": false, 
+          "percent": 0.0062
+        }, 
+        {
+          "lang": "bra", 
+          "official": false, 
+          "percent": 0.0041
+        }, 
+        {
+          "lang": "lep", 
+          "official": false, 
+          "percent": 0.0035
+        }, 
+        {
+          "lang": "btv", 
+          "official": false, 
+          "percent": 0.0026
+        }, 
+        {
+          "lang": "lif", 
+          "official": false, 
+          "percent": 0.0026
+        }, 
+        {
+          "lang": "lah", 
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        {
+          "lang": "sa", 
+          "official": true, 
+          "percent": 0.0012
+        }, 
+        {
+          "lang": "kht", 
+          "official": false, 
+          "percent": 0.0007
+        }, 
+        {
+          "lang": "dv", 
+          "official": false, 
+          "percent": 0.0004
+        }, 
+        {
+          "lang": "dz", 
+          "official": false, 
+          "percent": 0.0002
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AX", 
+      "languages": [
+        {
+          "lang": "sv", 
+          "official": true, 
+          "percent": 99.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IC", 
+      "languages": [
+        {
+          "lang": "es", 
+          "official": true, 
+          "percent": 98.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "AZ", 
+      "languages": [
+        {
+          "lang": "az", 
+          "official": true, 
+          "percent": 89.0
+        }, 
+        {
+          "lang": "az_Cyrl", 
+          "official": true, 
+          "percent": 9.9
+        }, 
+        {
+          "lang": "tly", 
+          "official": false, 
+          "percent": 9.8
+        }, 
+        {
+          "lang": "ku", 
+          "official": false, 
+          "percent": 0.24
+        }, 
+        {
+          "lang": "ttt", 
+          "official": false, 
+          "percent": 0.22
+        }, 
+        {
+          "lang": "tkr", 
+          "official": false, 
+          "percent": 0.16
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "IE", 
+      "languages": [
+        {
+          "lang": "en", 
+          "official": true, 
+          "percent": 98.0
+        }, 
+        {
+          "lang": "ga", 
+          "official": true, 
+          "percent": 22.0
+        }, 
+        {
+          "lang": "fr", 
+          "official": false, 
+          "percent": 17.0
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "ID", 
+      "languages": [
+        {
+          "lang": "id", 
+          "official": true, 
+          "percent": 64.0
+        }, 
+        {
+          "lang": "jv", 
+          "official": false, 
+          "percent": 34.0
+        }, 
+        {
+          "lang": "su", 
+          "official": false, 
+          "percent": 12.0
+        }, 
+        {
+          "lang": "mad", 
+          "official": false, 
+          "percent": 6.3
+        }, 
+        {
+          "lang": "ms_Arab", 
+          "official": false, 
+          "percent": 4.6
+        }, 
+        {
+          "lang": "min", 
+          "official": false, 
+          "percent": 3.0
+        }, 
+        {
+          "lang": "bew", 
+          "official": false, 
+          "percent": 2.1
+        }, 
+        {
+          "lang": "ban", 
+          "official": false, 
+          "percent": 1.8
+        }, 
+        {
+          "lang": "bug", 
+          "official": false, 
+          "percent": 1.6
+        }, 
+        {
+          "lang": "bjn", 
+          "official": false, 
+          "percent": 1.5
+        }, 
+        {
+          "lang": "ace", 
+          "official": false, 
+          "percent": 1.4
+        }, 
+        {
+          "lang": "sas", 
+          "official": false, 
+          "percent": 0.97
+        }, 
+        {
+          "lang": "bbc", 
+          "official": false, 
+          "percent": 0.92
+        }, 
+        {
+          "lang": "zh_Hant", 
+          "official": false, 
+          "percent": 0.92
+        }, 
+        {
+          "lang": "mak", 
+          "official": false, 
+          "percent": 0.73
+        }, 
+        {
+          "lang": "ljp", 
+          "official": false, 
+          "percent": 0.69
+        }, 
+        {
+          "lang": "rej", 
+          "official": false, 
+          "percent": 0.46
+        }, 
+        {
+          "lang": "gor", 
+          "official": false, 
+          "percent": 0.41
+        }, 
+        {
+          "lang": "nij", 
+          "official": false, 
+          "percent": 0.37
+        }, 
+        {
+          "lang": "kge", 
+          "official": false, 
+          "percent": 0.32
+        }, 
+        {
+          "lang": "aoz", 
+          "official": false, 
+          "percent": 0.27
+        }, 
+        {
+          "lang": "kvr", 
+          "official": false, 
+          "percent": 0.14
+        }, 
+        {
+          "lang": "lbw", 
+          "official": false, 
+          "percent": 0.13
+        }, 
+        {
+          "lang": "gay", 
+          "official": false, 
+          "percent": 0.12
+        }, 
+        {
+          "lang": "rob", 
+          "official": false, 
+          "percent": 0.11
+        }, 
+        {
+          "lang": "mdr", 
+          "official": false, 
+          "percent": 0.092
+        }, 
+        {
+          "lang": "sxn", 
+          "official": false, 
+          "percent": 0.092
+        }, 
+        {
+          "lang": "sly", 
+          "official": false, 
+          "percent": 0.054
+        }, 
+        {
+          "lang": "mwv", 
+          "official": false, 
+          "percent": 0.024
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "UA", 
+      "languages": [
+        {
+          "lang": "uk", 
+          "official": true, 
+          "percent": 65.0
+        }, 
+        {
+          "lang": "ru", 
+          "official": true, 
+          "percent": 46.0
+        }, 
+        {
+          "lang": "pl", 
+          "official": false, 
+          "percent": 2.4
+        }, 
+        {
+          "lang": "yi", 
+          "official": false, 
+          "percent": 1.3
+        }, 
+        {
+          "lang": "rue", 
+          "official": false, 
+          "percent": 1.2
+        }, 
+        {
+          "lang": "be", 
+          "official": false, 
+          "percent": 0.83
+        }, 
+        {
+          "lang": "crh", 
+          "official": false, 
+          "percent": 0.56
+        }, 
+        {
+          "lang": "ro", 
+          "official": false, 
+          "percent": 0.52
+        }, 
+        {
+          "lang": "bg", 
+          "official": false, 
+          "percent": 0.49
+        }, 
+        {
+          "lang": "tr", 
+          "official": false, 
+          "percent": 0.42
+        }, 
+        {
+          "lang": "hu", 
+          "official": false, 
+          "percent": 0.37
+        }, 
+        {
+          "lang": "el", 
+          "official": false, 
+          "percent": 0.016
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "QA", 
+      "languages": [
+        {
+          "lang": "ar", 
+          "official": true, 
+          "percent": 89.0
+        }, 
+        {
+          "lang": "fa", 
+          "official": false, 
+          "percent": 11.0
+        }, 
+        {
+          "lang": "ml", 
+          "official": false, 
+          "percent": 0.28
+        }
+      ]
+    }, 
+    {
+      "alpha_2": "MZ", 
+      "languages": [
+        {
+          "lang": "pt", 
+          "official": true, 
+          "percent": 27.0
+        }, 
+        {
+          "lang": "vmw", 
+          "official": false, 
+          "percent": 13.0
+        }, 
+        {
+          "lang": "ndc", 
+          "official": false, 
+          "percent": 9.9
+        }, 
+        {
+          "lang": "ts", 
+          "official": false, 
+          "percent": 7.9
+        }, 
+        {
+          "lang": "ngl", 
+          "official": false, 
+          "percent": 6.8
+        }, 
+        {
+          "lang": "seh", 
+          "official": false, 
+          "percent": 4.6
+        }, 
+        {
+          "lang": "mgh", 
+          "official": false, 
+          "percent": 4.5
+        }, 
+        {
+          "lang": "rng", 
+          "official": false, 
+          "percent": 3.4
+        }, 
+        {
+          "lang": "ny", 
+          "official": false, 
+          "percent": 2.6
+        }, 
+        {
+          "lang": "yao", 
+          "official": false, 
+          "percent": 2.4
+        }, 
+        {
+          "lang": "sw", 
+          "official": false, 
+          "percent": 0.035
+        }, 
+        {
+          "lang": "zu", 
           "official": false, 
           "percent": 0.0068
         }
-      }
+      ]
     }
   ]
 }

--- a/databases/iso_territory_languages.json
+++ b/databases/iso_territory_languages.json
@@ -1,0 +1,6788 @@
+{
+  "territory_languages": [
+    {
+      "alpha_2": "BD", 
+      "languages": {
+        "bn": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "ccp": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "grt": {
+          "official": false, 
+          "percent": 0.073
+        }, 
+        "mni": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "mro": {
+          "official": false, 
+          "percent": 0.018
+        }, 
+        "my": {
+          "official": false, 
+          "percent": 0.21
+        }, 
+        "rkt": {
+          "official": false, 
+          "percent": 6.5
+        }, 
+        "syl": {
+          "official": false, 
+          "percent": 5.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BE", 
+      "languages": {
+        "de": {
+          "official": true, 
+          "percent": 22.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 59.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 38.0
+        }, 
+        "nl": {
+          "official": true, 
+          "percent": 55.0
+        }, 
+        "vls": {
+          "official": false, 
+          "percent": 10.0
+        }, 
+        "wa": {
+          "official": false, 
+          "percent": 5.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BF", 
+      "languages": {
+        "dyu": {
+          "official": false, 
+          "percent": 32.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 22.0
+        }, 
+        "mos": {
+          "official": false, 
+          "percent": 40.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BG", 
+      "languages": {
+        "bg": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 8.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 25.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 23.0
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 11.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BA", 
+      "languages": {
+        "bs": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "bs_Cyrl": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 45.0
+        }, 
+        "hr": {
+          "official": true, 
+          "percent": 12.0
+        }, 
+        "sr": {
+          "official": true, 
+          "percent": 10.0
+        }, 
+        "sr_Latn": {
+          "official": true, 
+          "percent": 10.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BB", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "WF", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 48.0
+        }, 
+        "fud": {
+          "official": false, 
+          "percent": 31.0
+        }, 
+        "wls": {
+          "official": false, 
+          "percent": 60.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BL", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 92.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BN", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 1.8
+        }, 
+        "ms": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "ms_Arab": {
+          "official": true, 
+          "percent": 5.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 11.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BO", 
+      "languages": {
+        "aro": {
+          "official": false, 
+          "percent": 0.001
+        }, 
+        "ay": {
+          "official": true, 
+          "percent": 20.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "gn": {
+          "official": false, 
+          "percent": 0.45
+        }, 
+        "qu": {
+          "official": true, 
+          "percent": 32.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BH", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 87.0
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 3.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BI", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 0.054
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 59.0
+        }, 
+        "rn": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "sw": {
+          "official": false, 
+          "percent": 0.055
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BJ", 
+      "languages": {
+        "fon": {
+          "official": false, 
+          "percent": 25.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 35.0
+        }, 
+        "yo": {
+          "official": false, 
+          "percent": 6.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BT", 
+      "languages": {
+        "dz": {
+          "official": true, 
+          "percent": 47.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "lep": {
+          "official": false, 
+          "percent": 3.9
+        }, 
+        "ne": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "tsj": {
+          "official": false, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "JM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "jam": {
+          "official": false, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BV", 
+      "languages": {
+        "und": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BW", 
+      "languages": {
+        "af": {
+          "official": false, 
+          "percent": 0.27
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 81.0
+        }, 
+        "tn": {
+          "official": true, 
+          "percent": 62.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "WS", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 2.2
+        }, 
+        "sm": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BQ", 
+      "languages": {
+        "nl": {
+          "official": true, 
+          "percent": 8.0
+        }, 
+        "pap": {
+          "official": false, 
+          "percent": 81.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BR", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 0.84
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 8.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 0.037
+        }, 
+        "gub": {
+          "official": false, 
+          "percent": 0.0084
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 0.28
+        }, 
+        "ja": {
+          "official": false, 
+          "percent": 0.21
+        }, 
+        "kgp": {
+          "official": false, 
+          "percent": 0.01
+        }, 
+        "ko": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 91.0
+        }, 
+        "xav": {
+          "official": false, 
+          "percent": 0.0048
+        }, 
+        "yrl": {
+          "official": false, 
+          "percent": 0.0052
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BS", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "JE", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BY", 
+      "languages": {
+        "be": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "ru": {
+          "official": true, 
+          "percent": 12.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "BZ", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 28.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "RU", 
+      "languages": {
+        "ady": {
+          "official": true, 
+          "percent": 0.088
+        }, 
+        "alt": {
+          "official": false, 
+          "percent": 0.014
+        }, 
+        "av": {
+          "official": true, 
+          "percent": 0.39
+        }, 
+        "az_Cyrl": {
+          "official": true, 
+          "percent": 0.093
+        }, 
+        "ba": {
+          "official": true, 
+          "percent": 1.3
+        }, 
+        "bua": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "ce": {
+          "official": true, 
+          "percent": 0.66
+        }, 
+        "chm": {
+          "official": false, 
+          "percent": 0.37
+        }, 
+        "cu": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "cv": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "dar": {
+          "official": false, 
+          "percent": 0.26
+        }, 
+        "fi": {
+          "official": false, 
+          "percent": 0.012
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 0.84
+        }, 
+        "inh": {
+          "official": true, 
+          "percent": 0.16
+        }, 
+        "izh": {
+          "official": false, 
+          "percent": 0.0001
+        }, 
+        "kbd": {
+          "official": true, 
+          "percent": 0.31
+        }, 
+        "koi": {
+          "official": true, 
+          "percent": 0.045
+        }, 
+        "krc": {
+          "official": true, 
+          "percent": 0.16
+        }, 
+        "krl": {
+          "official": false, 
+          "percent": 0.082
+        }, 
+        "kum": {
+          "official": true, 
+          "percent": 0.2
+        }, 
+        "kv": {
+          "official": true, 
+          "percent": 0.18
+        }, 
+        "lbe": {
+          "official": true, 
+          "percent": 0.078
+        }, 
+        "lez": {
+          "official": true, 
+          "percent": 0.18
+        }, 
+        "mdf": {
+          "official": true, 
+          "percent": 0.21
+        }, 
+        "mn": {
+          "official": false, 
+          "percent": 0.0015
+        }, 
+        "mrj": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "myv": {
+          "official": true, 
+          "percent": 0.31
+        }, 
+        "os": {
+          "official": false, 
+          "percent": 0.32
+        }, 
+        "ru": {
+          "official": true, 
+          "percent": 94.0
+        }, 
+        "sah": {
+          "official": true, 
+          "percent": 0.32
+        }, 
+        "sr_Latn": {
+          "official": false, 
+          "percent": 0.0035
+        }, 
+        "tt": {
+          "official": true, 
+          "percent": 1.4
+        }, 
+        "tyv": {
+          "official": true, 
+          "percent": 0.13
+        }, 
+        "udm": {
+          "official": true, 
+          "percent": 0.38
+        }, 
+        "vep": {
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        "vot": {
+          "official": false, 
+          "percent": 0.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "RW", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 15.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 0.019
+        }, 
+        "rw": {
+          "official": true, 
+          "percent": 77.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "RS", 
+      "languages": {
+        "hr": {
+          "official": true, 
+          "percent": 0.93
+        }, 
+        "hu": {
+          "official": true, 
+          "percent": 4.8
+        }, 
+        "ro": {
+          "official": true, 
+          "percent": 2.1
+        }, 
+        "sk": {
+          "official": true, 
+          "percent": 0.85
+        }, 
+        "sq": {
+          "official": false, 
+          "percent": 19.0
+        }, 
+        "sr": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "sr_Latn": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "uk": {
+          "official": true, 
+          "percent": 0.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TL", 
+      "languages": {
+        "pt": {
+          "official": true, 
+          "percent": 59.0
+        }, 
+        "tet": {
+          "official": true, 
+          "percent": 59.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "RE", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 89.0
+        }, 
+        "rcf": {
+          "official": false, 
+          "percent": 71.0
+        }, 
+        "ta": {
+          "official": false, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TM", 
+      "languages": {
+        "ku": {
+          "official": false, 
+          "percent": 0.41
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "tk": {
+          "official": true, 
+          "percent": 70.0
+        }, 
+        "uz": {
+          "official": false, 
+          "percent": 9.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TJ", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 0.012
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 0.78
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "tg": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "RO", 
+      "languages": {
+        "bg": {
+          "official": false, 
+          "percent": 0.031
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 0.21
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.019
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 31.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 10.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "hu": {
+          "official": false, 
+          "percent": 6.6
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 0.013
+        }, 
+        "ro": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "sr_Latn": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 0.13
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TK", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "tkl": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GW", 
+      "languages": {
+        "knf": {
+          "official": false, 
+          "percent": 2.6
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GU", 
+      "languages": {
+        "ch": {
+          "official": true, 
+          "percent": 22.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 91.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GT", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "quc": {
+          "official": true, 
+          "percent": 7.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GS", 
+      "languages": {
+        "und": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GR", 
+      "languages": {
+        "bg": {
+          "official": false, 
+          "percent": 0.27
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "el": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 51.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 9.0
+        }, 
+        "mk": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "pnt": {
+          "official": false, 
+          "percent": 3.7
+        }, 
+        "sq": {
+          "official": false, 
+          "percent": 0.093
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "tsd": {
+          "official": false, 
+          "percent": 0.0019
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GQ", 
+      "languages": {
+        "bvb": {
+          "official": false, 
+          "percent": 7.9
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 87.0
+        }, 
+        "fan": {
+          "official": false, 
+          "percent": 51.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 8.8
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 0.0001
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GP", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 90.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "JP", 
+      "languages": {
+        "ja": {
+          "official": true, 
+          "percent": 95.0
+        }, 
+        "ko": {
+          "official": false, 
+          "percent": 0.52
+        }, 
+        "ryu": {
+          "official": false, 
+          "percent": 0.77
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GY", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GF", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 77.0
+        }, 
+        "gcr": {
+          "official": false, 
+          "percent": 26.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 2.5
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GE", 
+      "languages": {
+        "ab": {
+          "official": true, 
+          "percent": 2.2
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "ka": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 0.89
+        }, 
+        "os": {
+          "official": true, 
+          "percent": 2.2
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 9.0
+        }, 
+        "xmf": {
+          "official": false, 
+          "percent": 11.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GD", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 96.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GB", 
+      "languages": {
+        "bn": {
+          "official": false, 
+          "percent": 0.67
+        }, 
+        "cy": {
+          "official": true, 
+          "percent": 0.77
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 19.0
+        }, 
+        "ga": {
+          "official": true, 
+          "percent": 0.026
+        }, 
+        "gd": {
+          "official": true, 
+          "percent": 0.099
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "ks": {
+          "official": false, 
+          "percent": 0.19
+        }, 
+        "kw": {
+          "official": false, 
+          "percent": 0.0031
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 0.035
+        }, 
+        "pa": {
+          "official": false, 
+          "percent": 0.79
+        }, 
+        "sco": {
+          "official": false, 
+          "percent": 2.7
+        }, 
+        "syl": {
+          "official": false, 
+          "percent": 0.51
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 0.049
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 0.54
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GA", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "puu": {
+          "official": false, 
+          "percent": 9.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SV", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 89.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GN", 
+      "languages": {
+        "ff": {
+          "official": false, 
+          "percent": 26.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 29.0
+        }, 
+        "kpe": {
+          "official": false, 
+          "percent": 3.8
+        }, 
+        "man_Nkoo": {
+          "official": false, 
+          "percent": 23.0
+        }, 
+        "nqo": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "sus": {
+          "official": false, 
+          "percent": 11.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 40.0
+        }, 
+        "man": {
+          "official": false, 
+          "percent": 29.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GL", 
+      "languages": {
+        "da": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "kl": {
+          "official": true, 
+          "percent": 84.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GI", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 80.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 50.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "GH", 
+      "languages": {
+        "abr": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "ada": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "ak": {
+          "official": true, 
+          "percent": 39.0
+        }, 
+        "ee": {
+          "official": true, 
+          "percent": 11.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 21.0
+        }, 
+        "gaa": {
+          "official": true, 
+          "percent": 2.8
+        }, 
+        "gur": {
+          "official": false, 
+          "percent": 3.5
+        }, 
+        "ha": {
+          "official": false, 
+          "percent": 0.87
+        }, 
+        "nzi": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "saf": {
+          "official": false, 
+          "percent": 0.015
+        }
+      }
+    }, 
+    {
+      "alpha_2": "OM", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 81.0
+        }, 
+        "bal": {
+          "official": false, 
+          "percent": 4.9
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 0.94
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TN", 
+      "languages": {
+        "aeb": {
+          "official": false, 
+          "percent": 90.0
+        }, 
+        "ar": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 74.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "JO", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 45.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TA", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HR", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 49.0
+        }, 
+        "hr": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "it": {
+          "official": true, 
+          "percent": 1.6
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HT", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 4.7
+        }, 
+        "ht": {
+          "official": true, 
+          "percent": 81.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HU", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 20.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "hr": {
+          "official": false, 
+          "percent": 0.32
+        }, 
+        "hu": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "ro": {
+          "official": false, 
+          "percent": 0.99
+        }, 
+        "sk": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "sl": {
+          "official": false, 
+          "percent": 0.051
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HK", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 51.0
+        }, 
+        "yue": {
+          "official": false, 
+          "percent": 90.0
+        }, 
+        "zh": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "zh_Hant": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HN", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 0.44
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 78.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "HM", 
+      "languages": {
+        "und": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VE", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 82.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PR", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 49.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 87.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PS", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PW", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 8.8
+        }, 
+        "pau": {
+          "official": true, 
+          "percent": 74.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PT", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 10.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 15.0
+        }, 
+        "gl": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 96.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SJ", 
+      "languages": {
+        "nb": {
+          "official": true, 
+          "percent": 56.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 45.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PY", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 2.9
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 3.2
+        }, 
+        "gn": {
+          "official": true, 
+          "percent": 80.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IQ", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 68.0
+        }, 
+        "az_Arab": {
+          "official": true, 
+          "percent": 1.8
+        }, 
+        "ckb": {
+          "official": true, 
+          "percent": 20.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 35.0
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 0.87
+        }, 
+        "lrc": {
+          "official": false, 
+          "percent": 0.61
+        }, 
+        "syr": {
+          "official": false, 
+          "percent": 0.5
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PA", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 69.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 0.16
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PF", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "ty": {
+          "official": true, 
+          "percent": 31.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 7.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 50.0
+        }, 
+        "ho": {
+          "official": true, 
+          "percent": 2.1
+        }, 
+        "tpi": {
+          "official": true, 
+          "percent": 71.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PE", 
+      "languages": {
+        "ay": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 73.0
+        }, 
+        "qu": {
+          "official": true, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PK", 
+      "languages": {
+        "bal": {
+          "official": false, 
+          "percent": 3.7
+        }, 
+        "bft": {
+          "official": false, 
+          "percent": 0.18
+        }, 
+        "bgn": {
+          "official": false, 
+          "percent": 0.57
+        }, 
+        "brh": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "btv": {
+          "official": false, 
+          "percent": 0.019
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 50.0
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 0.66
+        }, 
+        "gjk": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "gju": {
+          "official": false, 
+          "percent": 0.2
+        }, 
+        "hnd": {
+          "official": false, 
+          "percent": 0.41
+        }, 
+        "hno": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "khw": {
+          "official": false, 
+          "percent": 0.15
+        }, 
+        "ks": {
+          "official": false, 
+          "percent": 0.069
+        }, 
+        "kvx": {
+          "official": false, 
+          "percent": 0.16
+        }, 
+        "kxp": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "lah": {
+          "official": false, 
+          "percent": 40.0
+        }, 
+        "mvy": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "pa_Arab": {
+          "official": false, 
+          "percent": 70.0
+        }, 
+        "ps": {
+          "official": false, 
+          "percent": 15.0
+        }, 
+        "sd": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "skr": {
+          "official": false, 
+          "percent": 9.1
+        }, 
+        "tg_Arab": {
+          "official": false, 
+          "percent": 0.33
+        }, 
+        "ur": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PH", 
+      "languages": {
+        "bhk": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "bik": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "bku": {
+          "official": false, 
+          "percent": 0.0077
+        }, 
+        "bto": {
+          "official": false, 
+          "percent": 0.28
+        }, 
+        "ceb": {
+          "official": true, 
+          "percent": 24.0
+        }, 
+        "cps": {
+          "official": false, 
+          "percent": 0.67
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 64.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 31.0
+        }, 
+        "fil": {
+          "official": true, 
+          "percent": 60.0
+        }, 
+        "hil": {
+          "official": true, 
+          "percent": 8.4
+        }, 
+        "hnn": {
+          "official": false, 
+          "percent": 0.016
+        }, 
+        "ilo": {
+          "official": true, 
+          "percent": 9.6
+        }, 
+        "krj": {
+          "official": false, 
+          "percent": 0.39
+        }, 
+        "mdh": {
+          "official": true, 
+          "percent": 1.2
+        }, 
+        "pag": {
+          "official": true, 
+          "percent": 1.4
+        }, 
+        "pam": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "tbw": {
+          "official": false, 
+          "percent": 0.0096
+        }, 
+        "tsg": {
+          "official": true, 
+          "percent": 1.1
+        }, 
+        "war": {
+          "official": true, 
+          "percent": 2.9
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 0.73
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PN", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 85.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PL", 
+      "languages": {
+        "be": {
+          "official": false, 
+          "percent": 0.58
+        }, 
+        "csb": {
+          "official": true, 
+          "percent": 0.13
+        }, 
+        "de": {
+          "official": true, 
+          "percent": 19.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 33.0
+        }, 
+        "lt": {
+          "official": true, 
+          "percent": 0.021
+        }, 
+        "pl": {
+          "official": true, 
+          "percent": 96.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "sli": {
+          "official": false, 
+          "percent": 0.031
+        }, 
+        "szl": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "uk": {
+          "official": false, 
+          "percent": 0.39
+        }
+      }
+    }, 
+    {
+      "alpha_2": "PM", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 3.4
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 92.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ZM", 
+      "languages": {
+        "bem": {
+          "official": false, 
+          "percent": 31.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 16.0
+        }, 
+        "loz": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "ny": {
+          "official": false, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "EH", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "EE", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 50.0
+        }, 
+        "et": {
+          "official": true, 
+          "percent": 71.0
+        }, 
+        "fi": {
+          "official": false, 
+          "percent": 21.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 56.0
+        }, 
+        "vro": {
+          "official": false, 
+          "percent": 5.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "EG", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 94.0
+        }, 
+        "arz": {
+          "official": false, 
+          "percent": 64.0
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.061
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 35.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "EA", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ZA", 
+      "languages": {
+        "af": {
+          "official": true, 
+          "percent": 13.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 31.0
+        }, 
+        "hi": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "nr": {
+          "official": true, 
+          "percent": 1.6
+        }, 
+        "nso": {
+          "official": true, 
+          "percent": 9.4
+        }, 
+        "ss": {
+          "official": true, 
+          "percent": 2.7
+        }, 
+        "st": {
+          "official": true, 
+          "percent": 7.9
+        }, 
+        "sw": {
+          "official": false, 
+          "percent": 0.0018
+        }, 
+        "tn": {
+          "official": true, 
+          "percent": 8.2
+        }, 
+        "ts": {
+          "official": true, 
+          "percent": 4.4
+        }, 
+        "ve": {
+          "official": true, 
+          "percent": 2.3
+        }, 
+        "xh": {
+          "official": true, 
+          "percent": 18.0
+        }, 
+        "zu": {
+          "official": true, 
+          "percent": 24.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "EC", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 96.0
+        }, 
+        "qu": {
+          "official": true, 
+          "percent": 17.0
+        }, 
+        "qug": {
+          "official": false, 
+          "percent": 5.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IT", 
+      "languages": {
+        "ca": {
+          "official": false, 
+          "percent": 0.035
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "egl": {
+          "official": false, 
+          "percent": 0.05
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.035
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 34.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 6.3
+        }, 
+        "fur": {
+          "official": false, 
+          "percent": 0.06
+        }, 
+        "hr": {
+          "official": false, 
+          "percent": 0.0056
+        }, 
+        "it": {
+          "official": true, 
+          "percent": 95.0
+        }, 
+        "lij": {
+          "official": false, 
+          "percent": 0.86
+        }, 
+        "lmo": {
+          "official": false, 
+          "percent": 0.03
+        }, 
+        "nap": {
+          "official": false, 
+          "percent": 0.97
+        }, 
+        "pms": {
+          "official": false, 
+          "percent": 0.0099
+        }, 
+        "rgn": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "sc": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "scn": {
+          "official": false, 
+          "percent": 0.82
+        }, 
+        "sdc": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "sl": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "vec": {
+          "official": false, 
+          "percent": 1.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VN", 
+      "languages": {
+        "cjm": {
+          "official": false, 
+          "percent": 0.089
+        }, 
+        "vi": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 1.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ZZ", 
+      "languages": {}
+    }, 
+    {
+      "alpha_2": "SB", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "rug": {
+          "official": false, 
+          "percent": 1.5
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ET", 
+      "languages": {
+        "aa": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "am": {
+          "official": true, 
+          "percent": 33.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 43.0
+        }, 
+        "om": {
+          "official": false, 
+          "percent": 32.0
+        }, 
+        "sid": {
+          "official": false, 
+          "percent": 3.5
+        }, 
+        "so": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "ti": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "wal": {
+          "official": false, 
+          "percent": 1.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SO", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 34.0
+        }, 
+        "om": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "so": {
+          "official": true, 
+          "percent": 78.0
+        }, 
+        "sw": {
+          "official": false, 
+          "percent": 2.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ZW", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 42.0
+        }, 
+        "kck": {
+          "official": false, 
+          "percent": 5.3
+        }, 
+        "mxc": {
+          "official": false, 
+          "percent": 6.5
+        }, 
+        "nd": {
+          "official": true, 
+          "percent": 12.0
+        }, 
+        "ndc": {
+          "official": false, 
+          "percent": 6.1
+        }, 
+        "ny": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "sn": {
+          "official": true, 
+          "percent": 81.0
+        }, 
+        "tn": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "ve": {
+          "official": false, 
+          "percent": 0.64
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SA", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ES", 
+      "languages": {
+        "ast": {
+          "official": true, 
+          "percent": 1.3
+        }, 
+        "ca": {
+          "official": true, 
+          "percent": 17.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 24.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "eu": {
+          "official": true, 
+          "percent": 2.0
+        }, 
+        "ext": {
+          "official": false, 
+          "percent": 0.49
+        }, 
+        "gl": {
+          "official": true, 
+          "percent": 7.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ER", 
+      "languages": {
+        "aa": {
+          "official": false, 
+          "percent": 3.6
+        }, 
+        "ar": {
+          "official": true, 
+          "percent": 4.9
+        }, 
+        "byn": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 59.0
+        }, 
+        "ssy": {
+          "official": false, 
+          "percent": 3.6
+        }, 
+        "ti": {
+          "official": true, 
+          "percent": 60.0
+        }, 
+        "tig": {
+          "official": false, 
+          "percent": 18.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ME", 
+      "languages": {
+        "sq": {
+          "official": false, 
+          "percent": 7.9
+        }, 
+        "sr": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "sr_Latn": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MD", 
+      "languages": {
+        "bg": {
+          "official": false, 
+          "percent": 9.4
+        }, 
+        "gag": {
+          "official": false, 
+          "percent": 3.3
+        }, 
+        "ro": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "uk": {
+          "official": false, 
+          "percent": 14.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 18.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 69.0
+        }, 
+        "mg": {
+          "official": true, 
+          "percent": 90.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MF", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MA", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 62.0
+        }, 
+        "ary": {
+          "official": false, 
+          "percent": 87.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 0.065
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 20.0
+        }, 
+        "rif": {
+          "official": false, 
+          "percent": 4.9
+        }, 
+        "rif_Latn": {
+          "official": false, 
+          "percent": 4.9
+        }, 
+        "shi": {
+          "official": false, 
+          "percent": 8.7
+        }, 
+        "shi_Latn": {
+          "official": false, 
+          "percent": 8.7
+        }, 
+        "tzm": {
+          "official": true, 
+          "percent": 9.8
+        }, 
+        "zgh": {
+          "official": false, 
+          "percent": 22.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MC", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "UZ", 
+      "languages": {
+        "kaa": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 0.76
+        }, 
+        "uz": {
+          "official": true, 
+          "percent": 85.0
+        }, 
+        "uz_Cyrl": {
+          "official": true, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MM", 
+      "languages": {
+        "kac": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "kht": {
+          "official": false, 
+          "percent": 0.0077
+        }, 
+        "mnw": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "my": {
+          "official": true, 
+          "percent": 64.0
+        }, 
+        "shn": {
+          "official": false, 
+          "percent": 6.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ML", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 0.89
+        }, 
+        "bm": {
+          "official": false, 
+          "percent": 46.0
+        }, 
+        "bm_Nkoo": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "bmq": {
+          "official": false, 
+          "percent": 0.86
+        }, 
+        "bze": {
+          "official": false, 
+          "percent": 0.84
+        }, 
+        "dtm": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "ffm": {
+          "official": false, 
+          "percent": 7.7
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 46.0
+        }, 
+        "kao": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "khq": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "mwk": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "ses": {
+          "official": false, 
+          "percent": 3.4
+        }, 
+        "snk": {
+          "official": false, 
+          "percent": 5.9
+        }, 
+        "tmh": {
+          "official": false, 
+          "percent": 2.1
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MO", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 5.0
+        }, 
+        "zh": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "zh_Hant": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MN", 
+      "languages": {
+        "kk_Arab": {
+          "official": false, 
+          "percent": 7.2
+        }, 
+        "mn": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 0.13
+        }, 
+        "ug_Cyrl": {
+          "official": false, 
+          "percent": 0.033
+        }, 
+        "zh": {
+          "official": false, 
+          "percent": 1.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MH", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "mh": {
+          "official": true, 
+          "percent": 73.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MK", 
+      "languages": {
+        "mk": {
+          "official": true, 
+          "percent": 67.0
+        }, 
+        "sq": {
+          "official": true, 
+          "percent": 25.0
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 3.5
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MU", 
+      "languages": {
+        "bho": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 72.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 3.0
+        }, 
+        "mfe": {
+          "official": false, 
+          "percent": 90.0
+        }, 
+        "ta": {
+          "official": false, 
+          "percent": 2.5
+        }, 
+        "ur": {
+          "official": false, 
+          "percent": 5.2
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MT", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 88.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 56.0
+        }, 
+        "mt": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MW", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "ny": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "tog": {
+          "official": false, 
+          "percent": 0.98
+        }, 
+        "tum": {
+          "official": false, 
+          "percent": 8.4
+        }, 
+        "zu": {
+          "official": false, 
+          "percent": 0.33
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MV", 
+      "languages": {
+        "dv": {
+          "official": true, 
+          "percent": 94.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MQ", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MP", 
+      "languages": {
+        "ch": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 97.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MS", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 66.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MR", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 85.0
+        }, 
+        "ff": {
+          "official": false, 
+          "percent": 5.7
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "wo": {
+          "official": false, 
+          "percent": 0.27
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "gv": {
+          "official": true, 
+          "percent": 1.9
+        }
+      }
+    }, 
+    {
+      "alpha_2": "UG", 
+      "languages": {
+        "ach": {
+          "official": false, 
+          "percent": 3.7
+        }, 
+        "cgg": {
+          "official": false, 
+          "percent": 5.4
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 3.9
+        }, 
+        "hi": {
+          "official": false, 
+          "percent": 0.0056
+        }, 
+        "laj": {
+          "official": false, 
+          "percent": 3.8
+        }, 
+        "lg": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "myx": {
+          "official": false, 
+          "percent": 2.9
+        }, 
+        "nyn": {
+          "official": false, 
+          "percent": 6.3
+        }, 
+        "rw": {
+          "official": false, 
+          "percent": 2.1
+        }, 
+        "sw": {
+          "official": true, 
+          "percent": 75.0
+        }, 
+        "teo": {
+          "official": false, 
+          "percent": 3.9
+        }, 
+        "ttj": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "xog": {
+          "official": false, 
+          "percent": 5.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TZ", 
+      "languages": {
+        "asa": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "bez": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 69.0
+        }, 
+        "jmc": {
+          "official": false, 
+          "percent": 0.75
+        }, 
+        "kde": {
+          "official": false, 
+          "percent": 2.4
+        }, 
+        "ksb": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "lag": {
+          "official": false, 
+          "percent": 0.87
+        }, 
+        "mas": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "mgy": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "nym": {
+          "official": false, 
+          "percent": 3.3
+        }, 
+        "rof": {
+          "official": false, 
+          "percent": 0.75
+        }, 
+        "rwk": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "sbp": {
+          "official": false, 
+          "percent": 0.2
+        }, 
+        "suk": {
+          "official": false, 
+          "percent": 8.7
+        }, 
+        "sw": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "vun": {
+          "official": false, 
+          "percent": 0.75
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MY", 
+      "languages": {
+        "bjn": {
+          "official": false, 
+          "percent": 0.016
+        }, 
+        "bug": {
+          "official": false, 
+          "percent": 0.079
+        }, 
+        "dtp": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 21.0
+        }, 
+        "iba": {
+          "official": false, 
+          "percent": 2.5
+        }, 
+        "jv": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 0.15
+        }, 
+        "ms": {
+          "official": true, 
+          "percent": 75.0
+        }, 
+        "ta": {
+          "official": false, 
+          "percent": 4.2
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "zmi": {
+          "official": false, 
+          "percent": 1.2
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MX", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 83.0
+        }, 
+        "maz": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "nch": {
+          "official": false, 
+          "percent": 0.19
+        }, 
+        "nhe": {
+          "official": false, 
+          "percent": 0.39
+        }, 
+        "nhw": {
+          "official": false, 
+          "percent": 0.38
+        }, 
+        "sei": {
+          "official": false, 
+          "percent": 0.0007
+        }, 
+        "yua": {
+          "official": false, 
+          "percent": 0.67
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IL", 
+      "languages": {
+        "am": {
+          "official": false, 
+          "percent": 0.59
+        }, 
+        "ar": {
+          "official": true, 
+          "percent": 20.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 85.0
+        }, 
+        "he": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "hu": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "lad": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 0.096
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "ro": {
+          "official": false, 
+          "percent": 3.7
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "ti": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 3.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FR", 
+      "languages": {
+        "br": {
+          "official": false, 
+          "percent": 0.83
+        }, 
+        "ca": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "co": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 39.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "eu": {
+          "official": false, 
+          "percent": 0.13
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 99.0
+        }, 
+        "frp": {
+          "official": false, 
+          "percent": 0.094
+        }, 
+        "gsw": {
+          "official": false, 
+          "percent": 0.91
+        }, 
+        "ia": {
+          "official": false, 
+          "percent": 0.0002
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "nl": {
+          "official": false, 
+          "percent": 0.13
+        }, 
+        "oc": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "pcd": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "pt": {
+          "official": false, 
+          "percent": 1.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IO", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SH", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 69.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FI", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 70.0
+        }, 
+        "et": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "fi": {
+          "official": true, 
+          "percent": 94.0
+        }, 
+        "rmf": {
+          "official": false, 
+          "percent": 0.091
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 0.81
+        }, 
+        "se": {
+          "official": false, 
+          "percent": 0.036
+        }, 
+        "smn": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "sms": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "sv": {
+          "official": true, 
+          "percent": 44.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FJ", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 94.0
+        }, 
+        "fj": {
+          "official": true, 
+          "percent": 39.0
+        }, 
+        "hi": {
+          "official": false, 
+          "percent": 44.0
+        }, 
+        "hif": {
+          "official": true, 
+          "percent": 41.0
+        }, 
+        "rtm": {
+          "official": false, 
+          "percent": 0.27
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FK", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 96.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FM", 
+      "languages": {
+        "chk": {
+          "official": false, 
+          "percent": 30.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 57.0
+        }, 
+        "kos": {
+          "official": false, 
+          "percent": 7.7
+        }, 
+        "pon": {
+          "official": false, 
+          "percent": 23.0
+        }, 
+        "uli": {
+          "official": false, 
+          "percent": 2.9
+        }, 
+        "yap": {
+          "official": false, 
+          "percent": 6.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "FO", 
+      "languages": {
+        "fo": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NI", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 78.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NL", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 71.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 90.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 29.0
+        }, 
+        "fy": {
+          "official": true, 
+          "percent": 4.3
+        }, 
+        "gos": {
+          "official": false, 
+          "percent": 3.6
+        }, 
+        "id": {
+          "official": false, 
+          "percent": 1.8
+        }, 
+        "li": {
+          "official": false, 
+          "percent": 5.5
+        }, 
+        "nds": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "nl": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "rif_Latn": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "zea": {
+          "official": false, 
+          "percent": 1.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NO", 
+      "languages": {
+        "nb": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "nn": {
+          "official": true, 
+          "percent": 25.0
+        }, 
+        "se": {
+          "official": true, 
+          "percent": 0.29
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NA", 
+      "languages": {
+        "af": {
+          "official": false, 
+          "percent": 75.0
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 0.9
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 7.0
+        }, 
+        "hz": {
+          "official": false, 
+          "percent": 9.1
+        }, 
+        "kj": {
+          "official": false, 
+          "percent": 35.0
+        }, 
+        "naq": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "ng": {
+          "official": false, 
+          "percent": 21.0
+        }, 
+        "tn": {
+          "official": false, 
+          "percent": 0.56
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VU", 
+      "languages": {
+        "bi": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 83.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 50.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NC", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 96.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NE", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 0.21
+        }, 
+        "dje": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 29.0
+        }, 
+        "fuq": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "ha": {
+          "official": false, 
+          "percent": 41.0
+        }, 
+        "tmh": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "twq": {
+          "official": false, 
+          "percent": 0.042
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NF", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 76.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NG", 
+      "languages": {
+        "amo": {
+          "official": false, 
+          "percent": 0.0087
+        }, 
+        "ar": {
+          "official": false, 
+          "percent": 0.071
+        }, 
+        "bin": {
+          "official": false, 
+          "percent": 0.71
+        }, 
+        "cch": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "efi": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 53.0
+        }, 
+        "fuv": {
+          "official": false, 
+          "percent": 6.7
+        }, 
+        "ha": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "ha_Arab": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "ibb": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "ig": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "kaj": {
+          "official": false, 
+          "percent": 0.21
+        }, 
+        "kcg": {
+          "official": false, 
+          "percent": 0.093
+        }, 
+        "pcm": {
+          "official": false, 
+          "percent": 21.0
+        }, 
+        "tiv": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "yo": {
+          "official": true, 
+          "percent": 13.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NZ", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "mi": {
+          "official": true, 
+          "percent": 2.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NP", 
+      "languages": {
+        "awa": {
+          "official": false, 
+          "percent": 2.2
+        }, 
+        "bap": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "bfy": {
+          "official": false, 
+          "percent": 0.54
+        }, 
+        "bho": {
+          "official": false, 
+          "percent": 6.8
+        }, 
+        "bn": {
+          "official": false, 
+          "percent": 0.094
+        }, 
+        "bo": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "dty": {
+          "official": false, 
+          "percent": 2.5
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "ggn": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "gvr": {
+          "official": false, 
+          "percent": 0.29
+        }, 
+        "hi": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "jml": {
+          "official": false, 
+          "percent": 3.2
+        }, 
+        "lep": {
+          "official": false, 
+          "percent": 0.0096
+        }, 
+        "lif": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "mai": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "mgp": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "mrd": {
+          "official": false, 
+          "percent": 0.83
+        }, 
+        "ne": {
+          "official": true, 
+          "percent": 44.0
+        }, 
+        "new": {
+          "official": false, 
+          "percent": 3.3
+        }, 
+        "rjs": {
+          "official": false, 
+          "percent": 0.44
+        }, 
+        "taj": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "tdg": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "tdh": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "thl": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "thq": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "thr": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "tkt": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "tsf": {
+          "official": false, 
+          "percent": 0.43
+        }, 
+        "unr_Deva": {
+          "official": false, 
+          "percent": 0.019
+        }, 
+        "xsr": {
+          "official": false, 
+          "percent": 0.52
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NR", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 97.0
+        }, 
+        "na": {
+          "official": true, 
+          "percent": 71.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "NU", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 69.0
+        }, 
+        "niu": {
+          "official": true, 
+          "percent": 69.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CK", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "XK", 
+      "languages": {
+        "aln": {
+          "official": false, 
+          "percent": 74.0
+        }, 
+        "sq": {
+          "official": true, 
+          "percent": 92.0
+        }, 
+        "sr": {
+          "official": true, 
+          "percent": 5.0
+        }, 
+        "sr_Latn": {
+          "official": true, 
+          "percent": 5.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CI", 
+      "languages": {
+        "bci": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "bqv": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "dnj": {
+          "official": false, 
+          "percent": 4.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 49.0
+        }, 
+        "kfo": {
+          "official": false, 
+          "percent": 0.23
+        }, 
+        "sef": {
+          "official": false, 
+          "percent": 4.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CH", 
+      "languages": {
+        "de": {
+          "official": true, 
+          "percent": 73.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 61.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 21.0
+        }, 
+        "gsw": {
+          "official": true, 
+          "percent": 65.0
+        }, 
+        "it": {
+          "official": true, 
+          "percent": 4.3
+        }, 
+        "lmo": {
+          "official": false, 
+          "percent": 4.1
+        }, 
+        "pt": {
+          "official": false, 
+          "percent": 3.4
+        }, 
+        "rm": {
+          "official": true, 
+          "percent": 0.5
+        }, 
+        "rmo": {
+          "official": false, 
+          "percent": 0.29
+        }, 
+        "wae": {
+          "official": false, 
+          "percent": 0.12
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CO", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "guc": {
+          "official": false, 
+          "percent": 0.27
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CN", 
+      "languages": {
+        "bo": {
+          "official": true, 
+          "percent": 0.2
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 0.0045
+        }, 
+        "gan": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "hak": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "hsn": {
+          "official": false, 
+          "percent": 2.9
+        }, 
+        "ii": {
+          "official": false, 
+          "percent": 0.6
+        }, 
+        "khb": {
+          "official": false, 
+          "percent": 0.019
+        }, 
+        "kk_Arab": {
+          "official": false, 
+          "percent": 0.086
+        }, 
+        "ko": {
+          "official": true, 
+          "percent": 0.15
+        }, 
+        "ky_Arab": {
+          "official": false, 
+          "percent": 0.034
+        }, 
+        "lcp": {
+          "official": false, 
+          "percent": 0.0058
+        }, 
+        "lis": {
+          "official": false, 
+          "percent": 0.045
+        }, 
+        "lzh": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "mn_Mong": {
+          "official": true, 
+          "percent": 0.26
+        }, 
+        "nan": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "nxq": {
+          "official": false, 
+          "percent": 0.024
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 0.001
+        }, 
+        "tdd": {
+          "official": false, 
+          "percent": 0.019
+        }, 
+        "ug": {
+          "official": true, 
+          "percent": 0.55
+        }, 
+        "uz_Cyrl": {
+          "official": false, 
+          "percent": 0.0004
+        }, 
+        "vi": {
+          "official": false, 
+          "percent": 0.0005
+        }, 
+        "wuu": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "yue_Hans": {
+          "official": false, 
+          "percent": 5.2
+        }, 
+        "za": {
+          "official": true, 
+          "percent": 0.31
+        }, 
+        "zh": {
+          "official": true, 
+          "percent": 90.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CM", 
+      "languages": {
+        "agq": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "ar": {
+          "official": false, 
+          "percent": 0.39
+        }, 
+        "bas": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "bax": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "bbj": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "bfd": {
+          "official": false, 
+          "percent": 0.57
+        }, 
+        "bkm": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "bss": {
+          "official": false, 
+          "percent": 0.54
+        }, 
+        "bum": {
+          "official": false, 
+          "percent": 4.6
+        }, 
+        "byv": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "dua": {
+          "official": false, 
+          "percent": 0.48
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 38.0
+        }, 
+        "ewo": {
+          "official": false, 
+          "percent": 3.1
+        }, 
+        "ff": {
+          "official": false, 
+          "percent": 3.6
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 68.0
+        }, 
+        "ha_Arab": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "jgo": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "kkj": {
+          "official": false, 
+          "percent": 0.54
+        }, 
+        "ksf": {
+          "official": false, 
+          "percent": 0.32
+        }, 
+        "maf": {
+          "official": false, 
+          "percent": 0.73
+        }, 
+        "mgo": {
+          "official": false, 
+          "percent": 0.47
+        }, 
+        "mua": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "nmg": {
+          "official": false, 
+          "percent": 0.036
+        }, 
+        "nnh": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "yav": {
+          "official": false, 
+          "percent": 0.0092
+        }, 
+        "ybb": {
+          "official": false, 
+          "percent": 1.6
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CL", 
+      "languages": {
+        "arn": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 9.5
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CC", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 17.0
+        }, 
+        "ms_Arab": {
+          "official": false, 
+          "percent": 83.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CA", 
+      "languages": {
+        "atj": {
+          "official": false, 
+          "percent": 0.016
+        }, 
+        "chp": {
+          "official": false, 
+          "percent": 0.0022
+        }, 
+        "cr": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "crj": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "crk": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "crl": {
+          "official": false, 
+          "percent": 0.015
+        }, 
+        "crm": {
+          "official": false, 
+          "percent": 0.013
+        }, 
+        "csw": {
+          "official": false, 
+          "percent": 0.014
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "den": {
+          "official": false, 
+          "percent": 0.0065
+        }, 
+        "dgr": {
+          "official": false, 
+          "percent": 0.0074
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 22.0
+        }, 
+        "gwi": {
+          "official": false, 
+          "percent": 0.0016
+        }, 
+        "ikt": {
+          "official": true, 
+          "percent": 0.011
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "iu": {
+          "official": true, 
+          "percent": 0.042
+        }, 
+        "iu_Latn": {
+          "official": true, 
+          "percent": 0.042
+        }, 
+        "moe": {
+          "official": false, 
+          "percent": 0.033
+        }, 
+        "moh": {
+          "official": false, 
+          "percent": 0.0098
+        }, 
+        "nsk": {
+          "official": false, 
+          "percent": 0.0033
+        }, 
+        "pdt": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "scs": {
+          "official": false, 
+          "percent": 0.0035
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 0.045
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CG", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 84.0
+        }, 
+        "ln": {
+          "official": false, 
+          "percent": 2.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CF", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 49.0
+        }, 
+        "ln": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "sg": {
+          "official": true, 
+          "percent": 49.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CD", 
+      "languages": {
+        "fr": {
+          "official": true, 
+          "percent": 3.8
+        }, 
+        "kg": {
+          "official": true, 
+          "percent": 1.5
+        }, 
+        "ln": {
+          "official": true, 
+          "percent": 3.1
+        }, 
+        "lol": {
+          "official": false, 
+          "percent": 0.61
+        }, 
+        "lu": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "lua": {
+          "official": true, 
+          "percent": 9.6
+        }, 
+        "rw": {
+          "official": false, 
+          "percent": 0.38
+        }, 
+        "sw": {
+          "official": true, 
+          "percent": 50.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CZ", 
+      "languages": {
+        "cs": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 15.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 0.49
+        }, 
+        "sk": {
+          "official": false, 
+          "percent": 16.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CY", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "el": {
+          "official": true, 
+          "percent": 95.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 73.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "tr": {
+          "official": true, 
+          "percent": 23.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CX", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 63.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CR", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CP", 
+      "languages": {
+        "und": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CW", 
+      "languages": {
+        "es": {
+          "official": false, 
+          "percent": 3.8
+        }, 
+        "nl": {
+          "official": true, 
+          "percent": 8.0
+        }, 
+        "pap": {
+          "official": true, 
+          "percent": 81.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CV", 
+      "languages": {
+        "kea": {
+          "official": false, 
+          "percent": 91.0
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 76.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "CU", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SZ", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 80.0
+        }, 
+        "ss": {
+          "official": true, 
+          "percent": 58.0
+        }, 
+        "ts": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "zu": {
+          "official": false, 
+          "percent": 6.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SY", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 80.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 5.9
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 1.8
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 8.0
+        }, 
+        "syr": {
+          "official": false, 
+          "percent": 0.084
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SX", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 68.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "nl": {
+          "official": true, 
+          "percent": 3.8
+        }, 
+        "vic": {
+          "official": false, 
+          "percent": 7.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KG", 
+      "languages": {
+        "ky": {
+          "official": true, 
+          "percent": 48.0
+        }, 
+        "ru": {
+          "official": true, 
+          "percent": 36.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KE", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 0.046
+        }, 
+        "dav": {
+          "official": false, 
+          "percent": 0.82
+        }, 
+        "ebu": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 19.0
+        }, 
+        "gu": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "guz": {
+          "official": false, 
+          "percent": 4.9
+        }, 
+        "kam": {
+          "official": false, 
+          "percent": 7.6
+        }, 
+        "ki": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "kln": {
+          "official": false, 
+          "percent": 7.6
+        }, 
+        "luo": {
+          "official": false, 
+          "percent": 9.8
+        }, 
+        "luy": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "mas": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "mer": {
+          "official": false, 
+          "percent": 4.0
+        }, 
+        "om": {
+          "official": false, 
+          "percent": 0.47
+        }, 
+        "pa": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "pko": {
+          "official": false, 
+          "percent": 0.7
+        }, 
+        "saq": {
+          "official": false, 
+          "percent": 0.46
+        }, 
+        "so": {
+          "official": false, 
+          "percent": 1.3
+        }, 
+        "sw": {
+          "official": true, 
+          "percent": 66.0
+        }, 
+        "teo": {
+          "official": false, 
+          "percent": 0.74
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SS", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 27.0
+        }, 
+        "nus": {
+          "official": false, 
+          "percent": 5.6
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SR", 
+      "languages": {
+        "nl": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "srn": {
+          "official": false, 
+          "percent": 68.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 1.2
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KI", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "gil": {
+          "official": true, 
+          "percent": 60.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KH", 
+      "languages": {
+        "cja": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "kdt": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "km": {
+          "official": true, 
+          "percent": 89.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KN", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KM", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 66.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 56.0
+        }, 
+        "wni": {
+          "official": true, 
+          "percent": 34.0
+        }, 
+        "zdj": {
+          "official": true, 
+          "percent": 37.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ST", 
+      "languages": {
+        "pt": {
+          "official": true, 
+          "percent": 85.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SK", 
+      "languages": {
+        "cs": {
+          "official": false, 
+          "percent": 47.0
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 22.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 26.0
+        }, 
+        "hu": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 0.93
+        }, 
+        "sk": {
+          "official": true, 
+          "percent": 90.0
+        }, 
+        "uk": {
+          "official": false, 
+          "percent": 1.9
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KR", 
+      "languages": {
+        "ko": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SI", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 42.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 59.0
+        }, 
+        "hr": {
+          "official": false, 
+          "percent": 61.0
+        }, 
+        "hu": {
+          "official": false, 
+          "percent": 0.47
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 0.2
+        }, 
+        "sl": {
+          "official": true, 
+          "percent": 87.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KP", 
+      "languages": {
+        "ko": {
+          "official": true, 
+          "percent": 88.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KW", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SN", 
+      "languages": {
+        "bjt": {
+          "official": true, 
+          "percent": 0.61
+        }, 
+        "bsc": {
+          "official": true, 
+          "percent": 0.098
+        }, 
+        "dyo": {
+          "official": true, 
+          "percent": 2.6
+        }, 
+        "ff": {
+          "official": true, 
+          "percent": 21.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 39.0
+        }, 
+        "knf": {
+          "official": true, 
+          "percent": 0.21
+        }, 
+        "mey": {
+          "official": true, 
+          "percent": 0.049
+        }, 
+        "mfv": {
+          "official": true, 
+          "percent": 0.77
+        }, 
+        "sav": {
+          "official": true, 
+          "percent": 1.5
+        }, 
+        "snf": {
+          "official": true, 
+          "percent": 0.24
+        }, 
+        "srr": {
+          "official": true, 
+          "percent": 11.0
+        }, 
+        "tnr": {
+          "official": true, 
+          "percent": 0.023
+        }, 
+        "wo": {
+          "official": true, 
+          "percent": 70.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SM", 
+      "languages": {
+        "eo": {
+          "official": false, 
+          "percent": 0.89
+        }, 
+        "it": {
+          "official": true, 
+          "percent": 89.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SL", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 35.0
+        }, 
+        "kri": {
+          "official": false, 
+          "percent": 95.0
+        }, 
+        "men": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "tem": {
+          "official": false, 
+          "percent": 26.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SC", 
+      "languages": {
+        "crs": {
+          "official": false, 
+          "percent": 98.0
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 38.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 60.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KZ", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 6.4
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 15.0
+        }, 
+        "kk": {
+          "official": true, 
+          "percent": 64.0
+        }, 
+        "ru": {
+          "official": true, 
+          "percent": 72.0
+        }, 
+        "ug_Cyrl": {
+          "official": false, 
+          "percent": 2.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "KY", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "ms": {
+          "official": true, 
+          "percent": 14.0
+        }, 
+        "pa": {
+          "official": false, 
+          "percent": 0.16
+        }, 
+        "ta": {
+          "official": true, 
+          "percent": 2.1
+        }, 
+        "zh": {
+          "official": true, 
+          "percent": 77.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SE", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 86.0
+        }, 
+        "fi": {
+          "official": true, 
+          "percent": 2.2
+        }, 
+        "fit": {
+          "official": false, 
+          "percent": 0.55
+        }, 
+        "ia": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "rmu": {
+          "official": false, 
+          "percent": 0.095
+        }, 
+        "se": {
+          "official": false, 
+          "percent": 0.33
+        }, 
+        "sma": {
+          "official": false, 
+          "percent": 0.003
+        }, 
+        "smj": {
+          "official": false, 
+          "percent": 0.015
+        }, 
+        "sv": {
+          "official": true, 
+          "percent": 95.0
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 0.03
+        }
+      }
+    }, 
+    {
+      "alpha_2": "SD", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "bej": {
+          "official": false, 
+          "percent": 5.4
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "fia": {
+          "official": false, 
+          "percent": 0.83
+        }, 
+        "fvr": {
+          "official": false, 
+          "percent": 2.7
+        }, 
+        "ha_Arab": {
+          "official": false, 
+          "percent": 1.8
+        }, 
+        "mls": {
+          "official": false, 
+          "percent": 0.99
+        }, 
+        "zag": {
+          "official": false, 
+          "percent": 0.51
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DO", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 0.075
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 78.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 94.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DJ", 
+      "languages": {
+        "aa": {
+          "official": false, 
+          "percent": 42.0
+        }, 
+        "ar": {
+          "official": true, 
+          "percent": 7.3
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 2.1
+        }, 
+        "so": {
+          "official": false, 
+          "percent": 41.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DK", 
+      "languages": {
+        "da": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "de": {
+          "official": true, 
+          "percent": 47.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 86.0
+        }, 
+        "fo": {
+          "official": false, 
+          "percent": 0.38
+        }, 
+        "jut": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "kl": {
+          "official": true, 
+          "percent": 0.12
+        }, 
+        "sv": {
+          "official": false, 
+          "percent": 13.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DE", 
+      "languages": {
+        "bar": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "da": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "de": {
+          "official": true, 
+          "percent": 91.0
+        }, 
+        "dsb": {
+          "official": false, 
+          "percent": 0.0087
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.38
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 64.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 18.0
+        }, 
+        "frr": {
+          "official": false, 
+          "percent": 0.012
+        }, 
+        "frs": {
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        "gsw": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "hr": {
+          "official": false, 
+          "percent": 0.79
+        }, 
+        "hsb": {
+          "official": false, 
+          "percent": 0.016
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "ksh": {
+          "official": false, 
+          "percent": 0.3
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 0.66
+        }, 
+        "nds": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "nl": {
+          "official": false, 
+          "percent": 9.0
+        }, 
+        "pfl": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 0.29
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 6.0
+        }, 
+        "stq": {
+          "official": false, 
+          "percent": 0.0012
+        }, 
+        "swg": {
+          "official": false, 
+          "percent": 1.0
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 2.5
+        }, 
+        "vmf": {
+          "official": false, 
+          "percent": 6.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "YE", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 74.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 9.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "DZ", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 74.0
+        }, 
+        "arq": {
+          "official": false, 
+          "percent": 83.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 20.0
+        }, 
+        "kab": {
+          "official": false, 
+          "percent": 7.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "US", 
+      "languages": {
+        "cho": {
+          "official": false, 
+          "percent": 0.0033
+        }, 
+        "chr": {
+          "official": false, 
+          "percent": 0.0077
+        }, 
+        "dak": {
+          "official": false, 
+          "percent": 0.0059
+        }, 
+        "de": {
+          "official": false, 
+          "percent": 0.47
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 96.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 9.6
+        }, 
+        "esu": {
+          "official": false, 
+          "percent": 0.0062
+        }, 
+        "fil": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "frc": {
+          "official": false, 
+          "percent": 0.0084
+        }, 
+        "haw": {
+          "official": true, 
+          "percent": 0.0089
+        }, 
+        "ik": {
+          "official": false, 
+          "percent": 0.0024
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "ko": {
+          "official": false, 
+          "percent": 0.3
+        }, 
+        "lkt": {
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        "mus": {
+          "official": false, 
+          "percent": 0.0012
+        }, 
+        "nv": {
+          "official": false, 
+          "percent": 0.05
+        }, 
+        "pdc": {
+          "official": false, 
+          "percent": 0.039
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "vi": {
+          "official": false, 
+          "percent": 0.34
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 0.049
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 0.69
+        }
+      }
+    }, 
+    {
+      "alpha_2": "UY", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 88.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "YT", 
+      "languages": {
+        "buc": {
+          "official": false, 
+          "percent": 23.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 57.0
+        }, 
+        "sw": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "swb": {
+          "official": false, 
+          "percent": 88.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "UM", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LB", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 40.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 0.37
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 5.2
+        }, 
+        "ku_Arab": {
+          "official": false, 
+          "percent": 1.6
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LC", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 90.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LA", 
+      "languages": {
+        "kdt": {
+          "official": false, 
+          "percent": 0.96
+        }, 
+        "kjg": {
+          "official": false, 
+          "percent": 5.8
+        }, 
+        "lo": {
+          "official": true, 
+          "percent": 69.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TV", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 9.7
+        }, 
+        "tvl": {
+          "official": true, 
+          "percent": 90.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TW", 
+      "languages": {
+        "trv": {
+          "official": false, 
+          "percent": 0.02
+        }, 
+        "zh_Hant": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TT", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 88.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 0.34
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TR", 
+      "languages": {
+        "ab": {
+          "official": false, 
+          "percent": 0.0049
+        }, 
+        "ady": {
+          "official": false, 
+          "percent": 0.39
+        }, 
+        "ar": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "az": {
+          "official": false, 
+          "percent": 0.74
+        }, 
+        "az_Arab": {
+          "official": false, 
+          "percent": 0.65
+        }, 
+        "bg": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "bgx": {
+          "official": false, 
+          "percent": 0.46
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.0049
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 0.056
+        }, 
+        "ka": {
+          "official": false, 
+          "percent": 0.056
+        }, 
+        "kbd": {
+          "official": false, 
+          "percent": 0.77
+        }, 
+        "kiu": {
+          "official": false, 
+          "percent": 0.19
+        }, 
+        "kk": {
+          "official": false, 
+          "percent": 0.0007
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 5.5
+        }, 
+        "ky_Latn": {
+          "official": false, 
+          "percent": 0.0014
+        }, 
+        "lzz": {
+          "official": false, 
+          "percent": 0.028
+        }, 
+        "sq": {
+          "official": false, 
+          "percent": 0.021
+        }, 
+        "sr_Latn": {
+          "official": false, 
+          "percent": 0.028
+        }, 
+        "tr": {
+          "official": true, 
+          "percent": 93.0
+        }, 
+        "tru": {
+          "official": false, 
+          "percent": 0.0037
+        }, 
+        "uz": {
+          "official": false, 
+          "percent": 0.0024
+        }, 
+        "zza": {
+          "official": false, 
+          "percent": 1.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LK", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 10.0
+        }, 
+        "si": {
+          "official": true, 
+          "percent": 68.0
+        }, 
+        "ta": {
+          "official": true, 
+          "percent": 15.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LI", 
+      "languages": {
+        "de": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "gsw": {
+          "official": true, 
+          "percent": 85.0
+        }, 
+        "wae": {
+          "official": false, 
+          "percent": 3.4
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LV", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 46.0
+        }, 
+        "ltg": {
+          "official": false, 
+          "percent": 8.9
+        }, 
+        "lv": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 38.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TO", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 28.0
+        }, 
+        "to": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LT", 
+      "languages": {
+        "de": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 38.0
+        }, 
+        "lt": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "ru": {
+          "official": false, 
+          "percent": 80.0
+        }, 
+        "sgs": {
+          "official": false, 
+          "percent": 0.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LU", 
+      "languages": {
+        "de": {
+          "official": true, 
+          "percent": 63.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 56.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 87.0
+        }, 
+        "lb": {
+          "official": true, 
+          "percent": 67.0
+        }, 
+        "pt": {
+          "official": false, 
+          "percent": 16.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LR", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 83.0
+        }, 
+        "kpe": {
+          "official": false, 
+          "percent": 14.0
+        }, 
+        "men": {
+          "official": false, 
+          "percent": 0.48
+        }, 
+        "vai": {
+          "official": false, 
+          "percent": 2.6
+        }, 
+        "vai_Latn": {
+          "official": false, 
+          "percent": 0.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LS", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 27.0
+        }, 
+        "ss": {
+          "official": false, 
+          "percent": 2.4
+        }, 
+        "st": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "xh": {
+          "official": false, 
+          "percent": 0.99
+        }, 
+        "zu": {
+          "official": false, 
+          "percent": 14.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TH", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 27.0
+        }, 
+        "kdt": {
+          "official": false, 
+          "percent": 0.48
+        }, 
+        "kxm": {
+          "official": false, 
+          "percent": 1.7
+        }, 
+        "lcp": {
+          "official": false, 
+          "percent": 0.01
+        }, 
+        "lwl": {
+          "official": false, 
+          "percent": 0.01
+        }, 
+        "mfa": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "mnw": {
+          "official": false, 
+          "percent": 0.17
+        }, 
+        "nod": {
+          "official": false, 
+          "percent": 9.6
+        }, 
+        "shn": {
+          "official": false, 
+          "percent": 0.096
+        }, 
+        "sou": {
+          "official": false, 
+          "percent": 8.0
+        }, 
+        "th": {
+          "official": true, 
+          "percent": 80.0
+        }, 
+        "tts": {
+          "official": false, 
+          "percent": 24.0
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 1.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TF", 
+      "languages": {
+        "fr": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TG", 
+      "languages": {
+        "ee": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 61.0
+        }, 
+        "ife": {
+          "official": false, 
+          "percent": 1.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TD", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 17.0
+        }, 
+        "fr": {
+          "official": true, 
+          "percent": 26.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "TC", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "LY", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 74.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VA", 
+      "languages": {
+        "it": {
+          "official": true, 
+          "percent": 82.0
+        }, 
+        "la": {
+          "official": false, 
+          "percent": 82.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AC", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VC", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 96.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AE", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 78.0
+        }, 
+        "bal": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "ps": {
+          "official": false, 
+          "percent": 2.9
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AD", 
+      "languages": {
+        "ca": {
+          "official": true, 
+          "percent": 51.0
+        }, 
+        "es": {
+          "official": false, 
+          "percent": 43.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 6.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AG", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 86.0
+        }, 
+        "pt": {
+          "official": false, 
+          "percent": 1.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AF", 
+      "languages": {
+        "bal": {
+          "official": true, 
+          "percent": 0.67
+        }, 
+        "bgn": {
+          "official": false, 
+          "percent": 0.63
+        }, 
+        "fa": {
+          "official": true, 
+          "percent": 50.0
+        }, 
+        "haz": {
+          "official": false, 
+          "percent": 5.9
+        }, 
+        "kk_Arab": {
+          "official": false, 
+          "percent": 0.0059
+        }, 
+        "prd": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "ps": {
+          "official": true, 
+          "percent": 43.0
+        }, 
+        "tk": {
+          "official": true, 
+          "percent": 1.7
+        }, 
+        "ug": {
+          "official": false, 
+          "percent": 0.0088
+        }, 
+        "uz_Arab": {
+          "official": true, 
+          "percent": 4.7
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AI", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 95.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "VI", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 75.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IS", 
+      "languages": {
+        "da": {
+          "official": false, 
+          "percent": 0.66
+        }, 
+        "is": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IR", 
+      "languages": {
+        "ar": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "az_Arab": {
+          "official": false, 
+          "percent": 24.0
+        }, 
+        "bal": {
+          "official": false, 
+          "percent": 2.0
+        }, 
+        "bgn": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "bqi": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "ckb": {
+          "official": false, 
+          "percent": 3.9
+        }, 
+        "fa": {
+          "official": true, 
+          "percent": 75.0
+        }, 
+        "gbz": {
+          "official": false, 
+          "percent": 0.0098
+        }, 
+        "glk": {
+          "official": false, 
+          "percent": 4.6
+        }, 
+        "hy": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "ka": {
+          "official": false, 
+          "percent": 0.071
+        }, 
+        "kk_Arab": {
+          "official": false, 
+          "percent": 0.0037
+        }, 
+        "lki": {
+          "official": false, 
+          "percent": 0.76
+        }, 
+        "lrc": {
+          "official": false, 
+          "percent": 2.1
+        }, 
+        "luz": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "mzn": {
+          "official": false, 
+          "percent": 5.0
+        }, 
+        "prd": {
+          "official": false, 
+          "percent": 0.5
+        }, 
+        "ps": {
+          "official": false, 
+          "percent": 0.16
+        }, 
+        "rmt": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "sdh": {
+          "official": false, 
+          "percent": 3.7
+        }, 
+        "tk": {
+          "official": false, 
+          "percent": 2.8
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AM", 
+      "languages": {
+        "az": {
+          "official": false, 
+          "percent": 0.0
+        }, 
+        "hy": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 3.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AL", 
+      "languages": {
+        "el": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "mk": {
+          "official": false, 
+          "percent": 0.47
+        }, 
+        "sq": {
+          "official": true, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AO", 
+      "languages": {
+        "kmb": {
+          "official": false, 
+          "percent": 25.0
+        }, 
+        "ln": {
+          "official": false, 
+          "percent": 0.67
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 67.0
+        }, 
+        "umb": {
+          "official": false, 
+          "percent": 29.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AQ", 
+      "languages": {
+        "und": {
+          "official": false, 
+          "percent": 100.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AS", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 97.0
+        }, 
+        "sm": {
+          "official": true, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AR", 
+      "languages": {
+        "cy": {
+          "official": false, 
+          "percent": 0.066
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 7.0
+        }, 
+        "es": {
+          "official": true, 
+          "percent": 100.0
+        }, 
+        "gn": {
+          "official": false, 
+          "percent": 0.047
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AU", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 96.0
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "wbp": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 2.1
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AT", 
+      "languages": {
+        "bar": {
+          "official": false, 
+          "percent": 95.0
+        }, 
+        "de": {
+          "official": true, 
+          "percent": 97.0
+        }, 
+        "en": {
+          "official": false, 
+          "percent": 73.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "hr": {
+          "official": true, 
+          "percent": 1.2
+        }, 
+        "hu": {
+          "official": true, 
+          "percent": 0.27
+        }, 
+        "it": {
+          "official": false, 
+          "percent": 9.0
+        }, 
+        "sl": {
+          "official": true, 
+          "percent": 0.37
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AW", 
+      "languages": {
+        "en": {
+          "official": false, 
+          "percent": 2.6
+        }, 
+        "nl": {
+          "official": true, 
+          "percent": 97.0
+        }, 
+        "pap": {
+          "official": true, 
+          "percent": 61.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IN", 
+      "languages": {
+        "as": {
+          "official": true, 
+          "percent": 1.3
+        }, 
+        "awa": {
+          "official": false, 
+          "percent": 1.9
+        }, 
+        "bfq": {
+          "official": false, 
+          "percent": 0.023
+        }, 
+        "bft": {
+          "official": false, 
+          "percent": 0.0062
+        }, 
+        "bfy": {
+          "official": false, 
+          "percent": 0.037
+        }, 
+        "bgc": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "bhb": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "bhi": {
+          "official": false, 
+          "percent": 0.092
+        }, 
+        "bho": {
+          "official": false, 
+          "percent": 2.3
+        }, 
+        "bjj": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "bn": {
+          "official": true, 
+          "percent": 8.1
+        }, 
+        "bo": {
+          "official": false, 
+          "percent": 0.011
+        }, 
+        "bpy": {
+          "official": false, 
+          "percent": 0.0068
+        }, 
+        "bra": {
+          "official": false, 
+          "percent": 0.0041
+        }, 
+        "brx": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "btv": {
+          "official": false, 
+          "percent": 0.0026
+        }, 
+        "ccp": {
+          "official": false, 
+          "percent": 0.028
+        }, 
+        "dcc": {
+          "official": false, 
+          "percent": 0.99
+        }, 
+        "doi": {
+          "official": false, 
+          "percent": 0.19
+        }, 
+        "dv": {
+          "official": false, 
+          "percent": 0.0004
+        }, 
+        "dz": {
+          "official": false, 
+          "percent": 0.0002
+        }, 
+        "en": {
+          "official": true, 
+          "percent": 19.0
+        }, 
+        "gbm": {
+          "official": false, 
+          "percent": 0.27
+        }, 
+        "gom": {
+          "official": false, 
+          "percent": 0.32
+        }, 
+        "gon": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "grt": {
+          "official": false, 
+          "percent": 0.053
+        }, 
+        "gu": {
+          "official": true, 
+          "percent": 4.5
+        }, 
+        "hi": {
+          "official": true, 
+          "percent": 41.0
+        }, 
+        "hne": {
+          "official": false, 
+          "percent": 1.1
+        }, 
+        "hoc": {
+          "official": false, 
+          "percent": 0.099
+        }, 
+        "hoj": {
+          "official": false, 
+          "percent": 0.082
+        }, 
+        "kfr": {
+          "official": false, 
+          "percent": 0.075
+        }, 
+        "kfy": {
+          "official": false, 
+          "percent": 0.22
+        }, 
+        "kha": {
+          "official": true, 
+          "percent": 0.08
+        }, 
+        "khn": {
+          "official": false, 
+          "percent": 0.15
+        }, 
+        "kht": {
+          "official": false, 
+          "percent": 0.0007
+        }, 
+        "kn": {
+          "official": true, 
+          "percent": 3.7
+        }, 
+        "kok": {
+          "official": true, 
+          "percent": 0.37
+        }, 
+        "kru": {
+          "official": false, 
+          "percent": 0.19
+        }, 
+        "ks": {
+          "official": true, 
+          "percent": 0.41
+        }, 
+        "lah": {
+          "official": false, 
+          "percent": 0.0025
+        }, 
+        "lep": {
+          "official": false, 
+          "percent": 0.0035
+        }, 
+        "lif": {
+          "official": false, 
+          "percent": 0.0026
+        }, 
+        "lmn": {
+          "official": false, 
+          "percent": 0.27
+        }, 
+        "mag": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "mai": {
+          "official": true, 
+          "percent": 1.2
+        }, 
+        "ml": {
+          "official": true, 
+          "percent": 3.2
+        }, 
+        "mni": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "mr": {
+          "official": true, 
+          "percent": 7.0
+        }, 
+        "mtr": {
+          "official": false, 
+          "percent": 0.098
+        }, 
+        "mwr": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "ne": {
+          "official": true, 
+          "percent": 0.56
+        }, 
+        "njo": {
+          "official": false, 
+          "percent": 0.023
+        }, 
+        "noe": {
+          "official": false, 
+          "percent": 0.13
+        }, 
+        "or": {
+          "official": true, 
+          "percent": 3.2
+        }, 
+        "pa": {
+          "official": true, 
+          "percent": 2.8
+        }, 
+        "raj": {
+          "official": false, 
+          "percent": 0.1
+        }, 
+        "ria": {
+          "official": false, 
+          "percent": 0.013
+        }, 
+        "rkt": {
+          "official": false, 
+          "percent": 0.44
+        }, 
+        "sa": {
+          "official": true, 
+          "percent": 0.0012
+        }, 
+        "sat": {
+          "official": true, 
+          "percent": 0.55
+        }, 
+        "saz": {
+          "official": false, 
+          "percent": 0.029
+        }, 
+        "sck": {
+          "official": false, 
+          "percent": 0.18
+        }, 
+        "sd": {
+          "official": true, 
+          "percent": 0.26
+        }, 
+        "sd_Deva": {
+          "official": true, 
+          "percent": 0.026
+        }, 
+        "srx": {
+          "official": false, 
+          "percent": 0.035
+        }, 
+        "swv": {
+          "official": false, 
+          "percent": 0.28
+        }, 
+        "ta": {
+          "official": true, 
+          "percent": 5.9
+        }, 
+        "tcy": {
+          "official": false, 
+          "percent": 0.15
+        }, 
+        "te": {
+          "official": true, 
+          "percent": 7.2
+        }, 
+        "unr": {
+          "official": false, 
+          "percent": 0.095
+        }, 
+        "unx": {
+          "official": false, 
+          "percent": 0.048
+        }, 
+        "ur": {
+          "official": true, 
+          "percent": 5.0
+        }, 
+        "wbq": {
+          "official": false, 
+          "percent": 0.18
+        }, 
+        "wbr": {
+          "official": false, 
+          "percent": 0.15
+        }, 
+        "wtm": {
+          "official": false, 
+          "percent": 0.46
+        }, 
+        "xnr": {
+          "official": false, 
+          "percent": 0.16
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AX", 
+      "languages": {
+        "sv": {
+          "official": true, 
+          "percent": 99.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IC", 
+      "languages": {
+        "es": {
+          "official": true, 
+          "percent": 98.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "AZ", 
+      "languages": {
+        "az": {
+          "official": true, 
+          "percent": 89.0
+        }, 
+        "az_Cyrl": {
+          "official": true, 
+          "percent": 9.9
+        }, 
+        "ku": {
+          "official": false, 
+          "percent": 0.24
+        }, 
+        "tkr": {
+          "official": false, 
+          "percent": 0.16
+        }, 
+        "tly": {
+          "official": false, 
+          "percent": 9.8
+        }, 
+        "ttt": {
+          "official": false, 
+          "percent": 0.22
+        }
+      }
+    }, 
+    {
+      "alpha_2": "IE", 
+      "languages": {
+        "en": {
+          "official": true, 
+          "percent": 98.0
+        }, 
+        "fr": {
+          "official": false, 
+          "percent": 17.0
+        }, 
+        "ga": {
+          "official": true, 
+          "percent": 22.0
+        }
+      }
+    }, 
+    {
+      "alpha_2": "ID", 
+      "languages": {
+        "ace": {
+          "official": false, 
+          "percent": 1.4
+        }, 
+        "aoz": {
+          "official": false, 
+          "percent": 0.27
+        }, 
+        "ban": {
+          "official": false, 
+          "percent": 1.8
+        }, 
+        "bbc": {
+          "official": false, 
+          "percent": 0.92
+        }, 
+        "bew": {
+          "official": false, 
+          "percent": 2.1
+        }, 
+        "bjn": {
+          "official": false, 
+          "percent": 1.5
+        }, 
+        "bug": {
+          "official": false, 
+          "percent": 1.6
+        }, 
+        "gay": {
+          "official": false, 
+          "percent": 0.12
+        }, 
+        "gor": {
+          "official": false, 
+          "percent": 0.41
+        }, 
+        "id": {
+          "official": true, 
+          "percent": 64.0
+        }, 
+        "jv": {
+          "official": false, 
+          "percent": 34.0
+        }, 
+        "kge": {
+          "official": false, 
+          "percent": 0.32
+        }, 
+        "kvr": {
+          "official": false, 
+          "percent": 0.14
+        }, 
+        "lbw": {
+          "official": false, 
+          "percent": 0.13
+        }, 
+        "ljp": {
+          "official": false, 
+          "percent": 0.69
+        }, 
+        "mad": {
+          "official": false, 
+          "percent": 6.3
+        }, 
+        "mak": {
+          "official": false, 
+          "percent": 0.73
+        }, 
+        "mdr": {
+          "official": false, 
+          "percent": 0.092
+        }, 
+        "min": {
+          "official": false, 
+          "percent": 3.0
+        }, 
+        "ms_Arab": {
+          "official": false, 
+          "percent": 4.6
+        }, 
+        "mwv": {
+          "official": false, 
+          "percent": 0.024
+        }, 
+        "nij": {
+          "official": false, 
+          "percent": 0.37
+        }, 
+        "rej": {
+          "official": false, 
+          "percent": 0.46
+        }, 
+        "rob": {
+          "official": false, 
+          "percent": 0.11
+        }, 
+        "sas": {
+          "official": false, 
+          "percent": 0.97
+        }, 
+        "sly": {
+          "official": false, 
+          "percent": 0.054
+        }, 
+        "su": {
+          "official": false, 
+          "percent": 12.0
+        }, 
+        "sxn": {
+          "official": false, 
+          "percent": 0.092
+        }, 
+        "zh_Hant": {
+          "official": false, 
+          "percent": 0.92
+        }
+      }
+    }, 
+    {
+      "alpha_2": "UA", 
+      "languages": {
+        "be": {
+          "official": false, 
+          "percent": 0.83
+        }, 
+        "bg": {
+          "official": false, 
+          "percent": 0.49
+        }, 
+        "crh": {
+          "official": false, 
+          "percent": 0.56
+        }, 
+        "el": {
+          "official": false, 
+          "percent": 0.016
+        }, 
+        "hu": {
+          "official": false, 
+          "percent": 0.37
+        }, 
+        "pl": {
+          "official": false, 
+          "percent": 2.4
+        }, 
+        "ro": {
+          "official": false, 
+          "percent": 0.52
+        }, 
+        "ru": {
+          "official": true, 
+          "percent": 46.0
+        }, 
+        "rue": {
+          "official": false, 
+          "percent": 1.2
+        }, 
+        "tr": {
+          "official": false, 
+          "percent": 0.42
+        }, 
+        "uk": {
+          "official": true, 
+          "percent": 65.0
+        }, 
+        "yi": {
+          "official": false, 
+          "percent": 1.3
+        }
+      }
+    }, 
+    {
+      "alpha_2": "QA", 
+      "languages": {
+        "ar": {
+          "official": true, 
+          "percent": 89.0
+        }, 
+        "fa": {
+          "official": false, 
+          "percent": 11.0
+        }, 
+        "ml": {
+          "official": false, 
+          "percent": 0.28
+        }
+      }
+    }, 
+    {
+      "alpha_2": "MZ", 
+      "languages": {
+        "mgh": {
+          "official": false, 
+          "percent": 4.5
+        }, 
+        "ndc": {
+          "official": false, 
+          "percent": 9.9
+        }, 
+        "ngl": {
+          "official": false, 
+          "percent": 6.8
+        }, 
+        "ny": {
+          "official": false, 
+          "percent": 2.6
+        }, 
+        "pt": {
+          "official": true, 
+          "percent": 27.0
+        }, 
+        "rng": {
+          "official": false, 
+          "percent": 3.4
+        }, 
+        "seh": {
+          "official": false, 
+          "percent": 4.6
+        }, 
+        "sw": {
+          "official": false, 
+          "percent": 0.035
+        }, 
+        "ts": {
+          "official": false, 
+          "percent": 7.9
+        }, 
+        "vmw": {
+          "official": false, 
+          "percent": 13.0
+        }, 
+        "yao": {
+          "official": false, 
+          "percent": 2.4
+        }, 
+        "zu": {
+          "official": false, 
+          "percent": 0.0068
+        }
+      }
+    }
+  ]
+}

--- a/scripts/languages.py
+++ b/scripts/languages.py
@@ -1,0 +1,26 @@
+import xml.etree.ElementTree as etree
+import urllib
+import json
+
+ISO = "territory_languages"
+FILE_NAME = "../databases/iso_{}.json".format(ISO)
+
+def get_languages(xml):
+    languages = {}
+    for t in xml.find('territoryInfo').findall('territory'):
+        langs = {}
+        for l in t.findall('languagePopulation'):
+            langs[l.get('type')] = {
+                'percent': float(l.get('populationPercent')),
+                'official': bool(l.get('officialStatus'))
+            }
+        languages[t.get('type')] = langs
+    return languages
+
+if __name__ == "__main__":
+    data = urllib.urlopen('http://unicode.org/repos/cldr/trunk/common/supplemental/supplementalData.xml').read()
+    xml = etree.XML(data)
+    with open(FILE_NAME, "w") as f:
+        f.write(json.dumps({
+            ISO: [{'alpha_2':k, 'languages':v} for k,v in get_languages(xml).items()]
+        }, sort_keys=True, indent=2))

--- a/scripts/make_territory_languages.py
+++ b/scripts/make_territory_languages.py
@@ -5,7 +5,7 @@ import json
 ISO = "territory_languages"
 FILE_NAME = "../databases/iso_{}.json".format(ISO)
 
-def get_languages(xml):
+def parse_languages(xml):
     languages = {}
     for t in xml.find('territoryInfo').findall('territory'):
         langs = {}
@@ -22,5 +22,5 @@ if __name__ == "__main__":
     xml = etree.XML(data)
     with open(FILE_NAME, "w") as f:
         f.write(json.dumps({
-            ISO: [{'alpha_2':k, 'languages':v} for k,v in get_languages(xml).items()]
+            ISO: [{'alpha_2':k, 'languages':v} for k,v in parse_languages(xml).items()]
         }, sort_keys=True, indent=2))

--- a/scripts/make_territory_languages.py
+++ b/scripts/make_territory_languages.py
@@ -14,7 +14,8 @@ def parse_languages(xml):
                 'percent': float(l.get('populationPercent')),
                 'official': bool(l.get('officialStatus'))
             }
-        languages[t.get('type')] = langs
+        langs = [dict(lang=k, **langs[k]) for k in sorted(langs.keys())]
+        languages[t.get('type')] = sorted(langs, key=lambda x: x['percent'], reverse=True)
     return languages
 
 if __name__ == "__main__":

--- a/src/AbstractDatabase.php
+++ b/src/AbstractDatabase.php
@@ -48,7 +48,7 @@ abstract class AbstractDatabase implements \Iterator, \Countable
         // abstract static methods not allowed on PHP < 7.0
         throw new \Exception(
             sprintf(
-                'Method "%s" must be inmpemented in class %s',
+                'Method "%s" must be implemented in class %s',
                 __METHOD__,
                 get_class()
             )

--- a/src/Database/Territory/Territory.php
+++ b/src/Database/Territory/Territory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Sokil\IsoCodes\Database\Territory;
+
+class Territory
+{
+    /**
+     * @var string
+     */
+    private $alpha2;
+
+    /**
+     * @var array
+     */
+    private $languages;
+
+    /**
+     * Country constructor.
+     *
+     * @param string $alpha2
+     * @param array $languages
+     */
+    public function __construct(
+        $alpha2,
+        $languages
+    ) {
+        $this->alpha2 = $alpha2;
+        $this->languages = $languages;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlpha2()
+    {
+        return $this->alpha2;
+    }
+
+    public function languages()
+    {
+        return $this->languages;
+    }
+}

--- a/src/Database/Territory/Territory.php
+++ b/src/Database/Territory/Territory.php
@@ -17,11 +17,6 @@ class Territory
     /**
      * @var array
      */
-    private $sortedLanguages;
-
-    /**
-     * @var array
-     */
     private $officialLanguages;
 
     /**
@@ -62,40 +57,12 @@ class Territory
     /**
      * @return array
      */
-    public function getSortedLanguages()
-    {
-        if ($this->sortedLanguages === null) {
-            $arr = $this->languages;
-            ksort($arr);
-            $arr = array_map(function ($k, $v) {
-                $v['language'] = $k;
-
-                return $v;
-            }, array_keys($arr), array_values($arr));
-            usort($arr, function ($x, $y) {
-                if ($x['percent'] === $y['percent']) {
-                    return 0;
-                }
-
-                return $x['percent'] > $y['percent'] ? -1 : 1;
-            });
-            $this->sortedLanguages = array_combine(array_map(function ($x) {
-                return $x['language'];
-            }, $arr), $arr);
-        }
-
-        return $this->sortedLanguages;
-    }
-
-    /**
-     * @return array
-     */
     public function getOfficialLanguages()
     {
         if ($this->officialLanguages === null) {
-            $this->officialLanguages = array_keys(array_filter($this->getSortedLanguages(), function ($v) {
+            $this->officialLanguages = array_filter($this->getLanguages(), function ($v) {
                 return $v['official'];
-            }));
+            });
         }
 
         return $this->officialLanguages;
@@ -107,9 +74,9 @@ class Territory
     public function getUnofficialLanguages()
     {
         if ($this->unofficialLanguages === null) {
-            $this->officialLanguages = array_keys(array_filter($this->getSortedLanguages(), function ($v) {
+            $this->officialLanguages = array_filter($this->getLanguages(), function ($v) {
                 return !$v['official'];
-            }));
+            });
         }
 
         return $this->unofficialLanguages;

--- a/src/Database/Territory/Territory.php
+++ b/src/Database/Territory/Territory.php
@@ -15,7 +15,22 @@ class Territory
     private $languages;
 
     /**
-     * Country constructor.
+     * @var array
+     */
+    private $sortedLanguages;
+
+    /**
+     * @var array
+     */
+    private $officialLanguages;
+
+    /**
+     * @var array
+     */
+    private $unofficialLanguages;
+
+    /**
+     * Territory constructor.
      *
      * @param string $alpha2
      * @param array $languages
@@ -36,8 +51,67 @@ class Territory
         return $this->alpha2;
     }
 
-    public function languages()
+    /**
+     * @return array
+     */
+    public function getLanguages()
     {
         return $this->languages;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSortedLanguages()
+    {
+        if ($this->sortedLanguages === null) {
+            $arr = $this->languages;
+            ksort($arr);
+            $arr = array_map(function ($k, $v) {
+                $v['language'] = $k;
+
+                return $v;
+            }, array_keys($arr), array_values($arr));
+            usort($arr, function ($x, $y) {
+                if ($x['percent'] === $y['percent']) {
+                    return 0;
+                }
+
+                return $x['percent'] > $y['percent'] ? -1 : 1;
+            });
+            $this->sortedLanguages = array_combine(array_map(function ($x) {
+                return $x['language'];
+            }, $arr), $arr);
+        }
+
+        return $this->sortedLanguages;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOfficialLanguages()
+    {
+        if ($this->officialLanguages === null) {
+            $this->officialLanguages = array_keys(array_filter($this->getSortedLanguages(), function ($v) {
+                return $v['official'];
+            }));
+        }
+
+        return $this->officialLanguages;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnofficialLanguages()
+    {
+        if ($this->unofficialLanguages === null) {
+            $this->officialLanguages = array_keys(array_filter($this->getSortedLanguages(), function ($v) {
+                return !$v['official'];
+            }));
+        }
+
+        return $this->unofficialLanguages;
     }
 }

--- a/src/Database/TerritoryLanguages.php
+++ b/src/Database/TerritoryLanguages.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sokil\IsoCodes\Database;
+
+use Sokil\IsoCodes\AbstractDatabase;
+use Sokil\IsoCodes\Database\Territory\Territory;
+
+class TerritoryLanguages extends AbstractDatabase
+{
+    public static function getISONumber()
+    {
+        return 'territory_languages';
+    }
+
+    /**
+     * @param array $entry
+     *
+     * @return Territory
+     */
+    protected function arrayToEntry(array $entry)
+    {
+        return new Territory(
+            $entry['alpha_2'],
+            $entry['languages']
+        );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getIndexDefinition()
+    {
+        return [
+            'alpha_2',
+        ];
+    }
+
+    /**
+     * @param string $alpha2
+     *
+     * @return null|Territory
+     */
+    public function getByAlpha2($alpha2)
+    {
+        return $this->find('alpha_2', $alpha2);
+    }
+
+
+}

--- a/src/Database/TerritoryLanguages.php
+++ b/src/Database/TerritoryLanguages.php
@@ -7,6 +7,8 @@ use Sokil\IsoCodes\Database\Territory\Territory;
 
 class TerritoryLanguages extends AbstractDatabase
 {
+    const UNKNOWN_COUNTRY = 'ZZ';
+
     public static function getISONumber()
     {
         return 'territory_languages';

--- a/src/IsoCodesFactory.php
+++ b/src/IsoCodesFactory.php
@@ -8,6 +8,7 @@ use Sokil\IsoCodes\Database\HistoricCountries;
 use Sokil\IsoCodes\Database\Languages;
 use Sokil\IsoCodes\Database\Scripts;
 use Sokil\IsoCodes\Database\Subdivisions;
+use Sokil\IsoCodes\Database\TerritoryLanguages;
 
 /**
  * Factory class to build ISO databases
@@ -90,5 +91,14 @@ class IsoCodesFactory
     public function getLanguages()
     {
         return $this->getDatabase(Languages::class);
+    }
+
+    /**
+     * Territory Languages
+     * @return TerritoryLanguages
+     */
+    public function getTerritoryLanguages()
+    {
+        return $this->getDatabase(TerritoryLanguages::class);
     }
 }

--- a/tests/Database/TerritoryLanguagesTest.php
+++ b/tests/Database/TerritoryLanguagesTest.php
@@ -3,6 +3,7 @@
 namespace Sokil\IsoCodes\Databases;
 
 use Sokil\IsoCodes\Database\Territory\Territory;
+use Sokil\IsoCodes\Database\TerritoryLanguages;
 use Sokil\IsoCodes\IsoCodesFactory;
 
 class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
@@ -56,7 +57,7 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
                 $territory
             );
             // NOTE: ZZ code is used for unspecified country
-            if ($territory->getAlpha2() !== 'ZZ') {
+            if ($territory->getAlpha2() !== TerritoryLanguages::UNKNOWN_COUNTRY) {
                 $this->assertNotEmpty(
                     $territory->getLanguages()
                 );

--- a/tests/Database/TerritoryLanguagesTest.php
+++ b/tests/Database/TerritoryLanguagesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sokil\IsoCodes\Databases;
+
+use Sokil\IsoCodes\Database\Territory\Territory;
+use Sokil\IsoCodes\IsoCodesFactory;
+
+class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIterator()
+    {
+        $isoCodes = new IsoCodesFactory();
+        $territories = $isoCodes->getTerritoryLanguages();
+        foreach ($territories as $territory) {
+            $this->assertInstanceOf(
+                Territory::class,
+                $territory
+            );
+        }
+
+        $this->assertInternalType('array', $territories->toArray());
+        $this->assertGreaterThan(0, count($territories));
+    }
+
+    public function testGetByAlpha2()
+    {
+        $isoCodes = new IsoCodesFactory();
+
+        $territories = $isoCodes->getTerritoryLanguages();
+        $territory = $territories->getByAlpha2('UA');
+
+        $this->assertInstanceOf(
+            Territory::class,
+            $territory
+        );
+
+        print_r($territory->languages());
+    }
+}

--- a/tests/Database/TerritoryLanguagesTest.php
+++ b/tests/Database/TerritoryLanguagesTest.php
@@ -34,7 +34,16 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
             $territory
         );
 
-        $this->assertArraySubset(['en', 'fr'], $territory->getOfficialLanguages());
+        $languages = $territory->getOfficialLanguages();
+        $this->assertInternalType('array', $languages);
+        $this->assertNotEmpty($languages);
+        foreach ($languages as $v) {
+            $this->assertArraySubset(['lang', 'official', 'percent'], array_keys($v));
+        }
+
+        $this->assertArraySubset(['en', 'fr'], array_map(function ($x) {
+            return $x['lang'];
+        }, $languages));
     }
 
     public function testLanguages()

--- a/tests/Database/TerritoryLanguagesTest.php
+++ b/tests/Database/TerritoryLanguagesTest.php
@@ -16,6 +16,12 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
                 Territory::class,
                 $territory
             );
+            // NOTE: omit ZZ code that is used for unspecified country
+            if($territory->getAlpha2() !== 'ZZ') {
+                $this->assertNotEmpty(
+                    $territory->getLanguages()
+                );
+            }
         }
 
         $this->assertInternalType('array', $territories->toArray());
@@ -27,13 +33,13 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
         $isoCodes = new IsoCodesFactory();
 
         $territories = $isoCodes->getTerritoryLanguages();
-        $territory = $territories->getByAlpha2('UA');
+        $territory = $territories->getByAlpha2('CA');
 
         $this->assertInstanceOf(
             Territory::class,
             $territory
         );
 
-        print_r($territory->languages());
+        $this->assertArraySubset(['en', 'fr'], $territory->getOfficialLanguages());
     }
 }

--- a/tests/Database/TerritoryLanguagesTest.php
+++ b/tests/Database/TerritoryLanguagesTest.php
@@ -16,12 +16,6 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
                 Territory::class,
                 $territory
             );
-            // NOTE: omit ZZ code that is used for unspecified country
-            if($territory->getAlpha2() !== 'ZZ') {
-                $this->assertNotEmpty(
-                    $territory->getLanguages()
-                );
-            }
         }
 
         $this->assertInternalType('array', $territories->toArray());
@@ -41,5 +35,40 @@ class TerritoryLanguagesTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(['en', 'fr'], $territory->getOfficialLanguages());
+    }
+
+    public function testLanguages()
+    {
+        $isoCodes = new IsoCodesFactory();
+        $territories = $isoCodes->getTerritoryLanguages();
+        foreach ($territories as $territory) {
+            $this->assertInstanceOf(
+                Territory::class,
+                $territory
+            );
+            // NOTE: ZZ code is used for unspecified country
+            if ($territory->getAlpha2() !== 'ZZ') {
+                $this->assertNotEmpty(
+                    $territory->getLanguages()
+                );
+
+                $this->assertGreaterThanOrEqual(
+                    count($territory->getUnofficialLanguages()),
+                    count($territory->getOfficialLanguages())
+                );
+            } else {
+                $this->assertEmpty(
+                    $territory->getLanguages()
+                );
+
+                $this->assertEmpty(
+                    count($territory->getOfficialLanguages())
+                );
+
+                $this->assertEmpty(
+                    count($territory->getUnofficialLanguages())
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
A territory-language relations based on data available from unicode.org list. This is not a real ISO standard/draft, just using the uniform handler to load.
A JSON db file can be updated with `python scripts/make_territory_languages.py` from the project directory.
As a further development, I can support reverse lookups to select territories, where particular language is used.
