### PR TITLE
Make GIT export only necessary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.* export-ignore
+/benchmarks export-ignore
+/infection.json.dist export-ignore
+/phpbench.json export-ignore
+/tests export-ignore


### PR DESCRIPTION
Some files in this repository are only useful for development purposes,
but when they should be there when GIT exports this repository.

For example, when downloading a release in GitHub, which is the same
that Composer does under the hood, those files should not be included.