### PR TITLE
Install packages when "vendor/" does not exist

### DIFF
--- a/update_db.sh
+++ b/update_db.sh
@@ -84,6 +84,10 @@ if [[ $? -eq 1 ]]; then
     fi
 fi
 
+if [[ ! -e "vendor/" ]]; then
+    $COMPOSER_PATH install
+fi
+
 $COMPOSER_PATH test
 
 # message on success test


### PR DESCRIPTION
The script that updates the database tries to execute the tests after
all the data is updated even when the packages are not installed.

This commit will install the packages with Composer when they are not
already installed. It will assume that because you don't have the
"vendor/" directory you probably didn't install the dependencies.