### PR TITLE
Fix numeric code types, they are numeric characters, not ints. Leadin…

### DIFF
--- a/src/Database/Countries.php
+++ b/src/Database/Countries.php
@@ -22,7 +22,7 @@ class Countries extends AbstractNotPartitionedDatabase
             $entry['name'],
             $entry['alpha_2'],
             $entry['alpha_3'],
-            (int)$entry['numeric'],
+            $entry['numeric'],
             !empty($entry['official_name']) ? $entry['official_name'] : null
         );
     }
@@ -49,7 +49,7 @@ class Countries extends AbstractNotPartitionedDatabase
         return $this->find('alpha_3', $alpha3);
     }
 
-    public function getByNumericCode(int $code): ?Country
+    public function getByNumericCode(string $code): ?Country
     {
         return $this->find('numeric', $code);
     }

--- a/src/Database/Countries/Country.php
+++ b/src/Database/Countries/Country.php
@@ -44,7 +44,7 @@ class Country
         string $name,
         string $alpha2,
         string $alpha3,
-        int $numericCode,
+        string $numericCode,
         ?string $officialName = null
     ) {
         $this->name = $name;
@@ -64,7 +64,7 @@ class Country
         return $this->alpha3;
     }
 
-    public function getNumericCode(): int
+    public function getNumericCode(): string
     {
         return $this->numericCode;
     }

--- a/tests/Database/CountriesTest.php
+++ b/tests/Database/CountriesTest.php
@@ -112,4 +112,27 @@ class CountriesTest extends TestCase
             $country->getLocalName()
         );
     }
+
+    public function testGetByNumericCodeLeadingZeroes(): void
+    {
+        $isoCodes = new IsoCodesFactory();
+
+        $countries = $isoCodes->getCountries();
+        $country = $countries->getByNumericCode('036');
+
+        $this->assertInstanceOf(
+            Country::class,
+            $country
+        );
+
+        $this->assertEquals(
+            'Australia',
+            $country->getName()
+        );
+
+        $this->assertSame(
+            '036',
+            $country->getNumericCode()
+        );
+    }
 }


### PR DESCRIPTION
Numeric codes are numeric characters, but not ints, leading zeroes matter.
Without this change both:

```
$isoCodes = new IsoCodesFactory();
$country = $countries->getByNumericCode('036');
```
and

```
$isoCodes = new IsoCodesFactory();
$country = $countries->getByNumericCode(36);
```

fail, because the map generated by \Sokil\IsoCodes\AbstractNotPartitionedDatabase::getIndex() has string array keys like '036' which doesn't match for numeric codes with leading zeroes that has been cast to an int