### PR TITLE
Fix AbstractDatabase iterator implementation for PHP 8.1

### DIFF
--- a/src/AbstractDatabase.php
+++ b/src/AbstractDatabase.php
@@ -179,6 +179,7 @@ abstract class AbstractDatabase implements \Iterator, \Countable
     /**
      * @return object
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->arrayToEntry(current($this->clusterIndex));


### PR DESCRIPTION
As reported in #53, PHP 8.1 adds a depreciation error if you don't specify return type or a new annotation on the `current()` function of `AbstractDatabase`. Another possibility is to define that `AbstractDatabase::current` returns `mixed`, but this breaks compatibility with PHP < 8.0.