### PR TITLE
Languages interface getByAlpha2 improvement with not null alpha2 language property

### DIFF
--- a/src/Database/Languages.php
+++ b/src/Database/Languages.php
@@ -6,6 +6,7 @@ namespace Sokil\IsoCodes\Database;
 
 use Sokil\IsoCodes\AbstractNotPartitionedDatabase;
 use Sokil\IsoCodes\Database\Languages\Language;
+use Sokil\IsoCodes\Database\LanguagesAlpha2\Language as LanguageAlpha2;
 
 /**
  * @method Language|null find(string $indexedFieldName, string $fieldValue)
@@ -49,9 +50,22 @@ class Languages extends AbstractNotPartitionedDatabase implements LanguagesInter
         ];
     }
 
-    public function getByAlpha2(string $alpha2): ?Language
+    public function getByAlpha2(string $alpha2): ?LanguageAlpha2
     {
-        return $this->find('alpha_2', $alpha2);
+        $language = $this->find('alpha_2', $alpha2);
+        if (! $language) {
+            return null;
+        }
+
+        return new LanguageAlpha2(
+            $this->translationDriver,
+            $language->getName(),
+            $language->getAlpha2(),
+            $language->getAlpha3(),
+            $language->getScope(),
+            $language->getType(),
+            $language->getInvertedName()
+        );
     }
 
     public function getByAlpha3(string $alpha3): ?Language

--- a/src/Database/LanguagesAlpha2/Language.php
+++ b/src/Database/LanguagesAlpha2/Language.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sokil\IsoCodes\Database\LanguagesAlpha2;
+
+use Sokil\IsoCodes\TranslationDriver\TranslatorInterface;
+
+class Language extends \Sokil\IsoCodes\Database\Languages\Language
+{
+    /** @var string */
+    private $alpha2;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        string $name,
+        string $alpha2,
+        string $alpha3,
+        string $scope,
+        string $type,
+        ?string $invertedName = null
+    ) {
+        parent::__construct($translator, $name, $alpha3, $scope, $type, $invertedName, $alpha2);
+        $this->alpha2 = $alpha2;
+    }
+
+    public function getAlpha2(): string
+    {
+        return $this->alpha2;
+    }
+}

--- a/src/Database/LanguagesInterface.php
+++ b/src/Database/LanguagesInterface.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Sokil\IsoCodes\Database;
 
 use Sokil\IsoCodes\Database\Languages\Language;
+use Sokil\IsoCodes\Database\LanguagesAlpha2\Language as LanguageAlpha2;
 
 interface LanguagesInterface extends \Iterator, \Countable
 {
-    public function getByAlpha2(string $alpha2): ?Language;
+    public function getByAlpha2(string $alpha2): ?LanguageAlpha2;
 
     public function getByAlpha3(string $alpha3): ?Language;
 }

--- a/src/Database/LanguagesPartitioned.php
+++ b/src/Database/LanguagesPartitioned.php
@@ -6,6 +6,7 @@ namespace Sokil\IsoCodes\Database;
 
 use Sokil\IsoCodes\AbstractPartitionedDatabase;
 use Sokil\IsoCodes\Database\Languages\Language;
+use Sokil\IsoCodes\Database\LanguagesAlpha2\Language as LanguageAlpha2;
 
 class LanguagesPartitioned extends AbstractPartitionedDatabase implements LanguagesInterface
 {
@@ -35,13 +36,29 @@ class LanguagesPartitioned extends AbstractPartitionedDatabase implements Langua
         );
     }
 
-    public function getByAlpha2(string $alpha2): ?Language
+    /**
+     * @param array<string, string> $entry
+     */
+    protected function arrayToEntryAlpha2(array $entry): LanguageAlpha2
+    {
+        return new LanguageAlpha2(
+            $this->translationDriver,
+            $entry['name'],
+            $entry['alpha_2'],
+            $entry['alpha_3'],
+            $entry['scope'],
+            $entry['type'],
+            !empty($entry['inverted_name']) ? $entry['inverted_name'] : null
+        );
+    }
+
+    public function getByAlpha2(string $alpha2): ?LanguageAlpha2
     {
         $language = null;
 
         foreach ($this->loadFromJSONFile('/alpha2/' . $alpha2[0]) as $languageRaw) {
             if ($languageRaw['alpha_2'] === $alpha2) {
-                $language = $this->arrayToEntry($languageRaw);
+                $language = $this->arrayToEntryAlpha2($languageRaw);
             }
         }
 


### PR DESCRIPTION
This improvement can help if library is used with strict static analysis.
Example like this will be correct:

```php
function example(string $lang)
{
}

$language = (new IsoCodesFactory())->getLanguages()->getByAlpha2('cs');
if(! $language) {
    //some code if null
} else {
    example($language->getAlpha2());
}
```

Language object searched by Alpha2 code will always contains Alpha2 string value.