### PR TITLE
Add Composer plugin dependencies to allow_plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
         "bench": "phpbench run benchmarks/  --report=default",
         "infection": "infection --min-msi=82 --min-covered-msi=91 --log-verbosity=default",
         "psalm": "./vendor/bin/psalm"
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
# Changed log

- When running the `php ~/composer.phar update` command to install dependencies in this repository, it will present the following error messages:

```
......
In PluginManager.php line 738:

  infection/extension-installer contains a Composer plugin which is blocked by your allow-plugins config.
   You may add it to the list if you consider it safe.
  You can run "composer config --no-plugins allow-plugins.infection/extension-installer [true|false]" to
  enable it (true) or disable it explicitly and suppress this exception (false)
  See https://getcomposer.org/allow-plugins
``` 

To resolve above error message, it should run the `php ~/composer.phar config --no-plugins allow-plugins.infection/extension-installer true` command to let the `infection/extension-installer` be allowed in this repository.