### PR TITLE
Add support to the most recent PHP versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,6 +19,9 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/src/AbstractDatabase.php
+++ b/src/AbstractDatabase.php
@@ -50,8 +50,8 @@ abstract class AbstractDatabase implements \Iterator, \Countable
      * @throws \RuntimeException when base directory not specified and directory can not be located automatically
      */
     public function __construct(
-        string $baseDirectory = null,
-        TranslationDriverInterface $translationDriver = null
+        ?string $baseDirectory = null,
+        ?TranslationDriverInterface $translationDriver = null
     ) {
         if (empty($baseDirectory)) {
             // Require external database in "sokil/php-isocodes-db-*" packages

--- a/src/IsoCodesFactory.php
+++ b/src/IsoCodesFactory.php
@@ -61,8 +61,8 @@ class IsoCodesFactory
     private $translationDriver;
 
     public function __construct(
-        string $baseDirectory = null,
-        TranslationDriverInterface $translationDriver = null
+        ?string $baseDirectory = null,
+        ?TranslationDriverInterface $translationDriver = null
     ) {
         $this->baseDirectory = $baseDirectory;
         $this->translationDriver = $translationDriver ?? new GettextExtensionDriver();


### PR DESCRIPTION
Hi there!

I've noticed that the library does not run in PHP 8.4, so I add the latest PHP versions and made some fixes, however, it seems like there's quite a lot to change.

* Are you planning to give support for the most recent PHP versions any time soon?
* Are you planning on dropping support to old PHP versions?