### PR TITLE
feat: Allow to use an existing translator

### DIFF
--- a/src/TranslationDriver/SymfonyTranslationDriver.php
+++ b/src/TranslationDriver/SymfonyTranslationDriver.php
@@ -23,7 +23,7 @@ class SymfonyTranslationDriver implements TranslationDriverInterface
     /**
      * @param string|null $cacheDirectory useful only if the given $translator is null.
      */
-    public function __construct(?TranslatorInterface $translator = null, ?string $cacheDirectory = null)
+    public function __construct(?string $cacheDirectory = null, ?TranslatorInterface $translator = null)
     {
         $this->translator = $translator ?: new Translator($this->locale, null, $cacheDirectory);
         $this->translator->addLoader('mo', new MoFileLoader());

--- a/src/TranslationDriver/SymfonyTranslationDriver.php
+++ b/src/TranslationDriver/SymfonyTranslationDriver.php
@@ -6,6 +6,7 @@ namespace Sokil\IsoCodes\TranslationDriver;
 
 use Symfony\Component\Translation\Loader\MoFileLoader;
 use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SymfonyTranslationDriver implements TranslationDriverInterface
 {
@@ -19,9 +20,12 @@ class SymfonyTranslationDriver implements TranslationDriverInterface
      */
     private $locale = 'en';
 
-    public function __construct(?string $cacheDirectory = null)
+    /**
+     * @param string|null $cacheDirectory useful only if the given $translator is null.
+     */
+    public function __construct(?TranslatorInterface $translator = null, ?string $cacheDirectory = null)
     {
-        $this->translator = new Translator($this->locale, null, $cacheDirectory);
+        $this->translator = $translator ?: new Translator($this->locale, null, $cacheDirectory);
         $this->translator->addLoader('mo', new MoFileLoader());
     }
 


### PR DESCRIPTION
# Problem and context
With the existing implementation, we cannot see potential missing translations and add them in our own translations files.

# Proposal
With this PR, we can use the existing translator from symfony that allow us to see the missing translations + add potential missing translations.

# Breaking change ?
None as the parameter is only used if it's not null and it'll be null by default.